### PR TITLE
add GetCurrentBossInfo mod.Call

### DIFF
--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -364,6 +364,23 @@ namespace BossChecklist
 			Array.Resize(ref args, 15);
 			try {
 				string message = args[0] as string;
+				if (message == "GetCurrentBossInfo") {
+					if (!bossTracker.BossesFinalized) {
+						Logger.Warn($"Call Warning: The attempted message, \"{message}\", was sent too early. Expect the Call message to return incomplete data. For best results, call in PostAddRecipes.");
+					}
+
+					//var bossStates = new List<ExpandoObject>();
+					//foreach (var boss in bossTracker.SortedBosses) {
+					//	bossStates.Add(boss.ConvertToExpandoObject());
+					//}
+					//return bossStates;
+
+					var bossInfos = new List<Dictionary<string, object>>();
+					foreach (var boss in bossTracker.SortedBosses) {
+						bossInfos.Add(boss.ConvertToDictionary());
+					}
+					return bossInfos;
+				}
 				if (bossTracker.BossesFinalized)
 					throw new Exception($"Call Error: The attempted message, \"{message}\", was sent too late. BossChecklist expects Call messages up until before AddRecipes.");
 				if (message == "AddBoss" || message == "AddBossWithInfo") { // For compatability reasons

--- a/BossChecklistIntegrationExample.cs
+++ b/BossChecklistIntegrationExample.cs
@@ -1,0 +1,80 @@
+﻿/*
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace <YourModsNamespace>
+{
+	// This class provides an example of Boss Checklist integration that other Mods can copy into their mods.
+	// By copying this class into your mod, you can access Boss Checklist boss data reliably and with type safety without requiring a strong dependency.
+	public static class BossChecklistIntegration
+	{
+		// Boss Checklist might add new features, so a version is passed into GetBossInfo. 
+		// If a new version of the GetBossInfo Call is implemented, find this class in the Boss Checklist Github once again and replace this version with the new version: https://github.com/JavidPack/BossChecklist/blob/master/BossChecklistIntegrationExample.cs
+		private static readonly Version BossChecklistAPIVersion = new Version(1, 1);
+
+		public class BossChecklistBossInfo
+		{
+			internal string key = ""; // equal to "modSource internalName"
+			internal string modSource = "";
+			internal string internalName = "";
+			internal string displayName = "";
+
+			internal float progression = 0f; // See https://github.com/JavidPack/BossChecklist/blob/master/BossTracker.cs#L13 for vanilla boss values
+			internal Func<bool> downed = () => false;
+
+			internal bool isBoss = false;
+			internal bool isMiniboss = false;
+			internal bool isEvent = false;
+
+			internal List<int> npcIDs = new List<int>(); // Does not include minions, only npcids that count towards the NPC still being alive.
+			internal List<int> spawnItem = new List<int>();
+			internal List<int> loot = new List<int>();
+			internal List<int> collection = new List<int>();
+		}
+
+		public static Dictionary<string, BossChecklistBossInfo> bossInfos = new Dictionary<string, BossChecklistBossInfo>();
+
+		public static bool DoBossChecklistIntegration() {
+			// Make sure to call this method in PostAddRecipes or later for best results
+			Mod BossChecklist = ModLoader.GetMod("BossChecklist");
+			if (BossChecklist != null && BossChecklist.Version >= BossChecklistAPIVersion) {
+				object currentBossInfoResponse = BossChecklist.Call("GetBossInfoDictionary", BossChecklistAPIVersion.ToString());
+				if (currentBossInfoResponse is Dictionary<string, Dictionary<string, object>> bossInfoList) {
+					bossInfos = bossInfoList.ToDictionary(boss => boss.Key, boss => new BossChecklistBossInfo() {
+						key = boss.Value.ContainsKey("key") ? boss.Value["key"] as string : "",
+						modSource = boss.Value.ContainsKey("modSource") ? boss.Value["modSource"] as string : "",
+						internalName = boss.Value.ContainsKey("internalName") ? boss.Value["internalName"] as string : "",
+						displayName = boss.Value.ContainsKey("displayName") ? boss.Value["displayName"] as string : "",
+
+						progression = boss.Value.ContainsKey("progression") ? Convert.ToSingle(boss.Value["progression"]) : 0f,
+						downed = boss.Value.ContainsKey("downed") ? boss.Value["downed"] as Func<bool> : () => false,
+
+						isBoss = boss.Value.ContainsKey("isBoss") ? Convert.ToBoolean(boss.Value["isBoss"]) : false,
+						isMiniboss = boss.Value.ContainsKey("isMiniboss") ? Convert.ToBoolean(boss.Value["isMiniboss"]) : false,
+						isEvent = boss.Value.ContainsKey("isEvent") ? Convert.ToBoolean(boss.Value["isEvent"]) : false,
+
+						npcIDs = boss.Value.ContainsKey("npcIDs") ? boss.Value["npcIDs"] as List<int> : new List<int>(),
+						spawnItem = boss.Value.ContainsKey("spawnItem") ? boss.Value["spawnItem"] as List<int> : new List<int>(),
+						loot = boss.Value.ContainsKey("loot") ? boss.Value["loot"] as List<int> : new List<int>(),
+						collection = boss.Value.ContainsKey("collection") ? boss.Value["collection"] as List<int> : new List<int>(),
+					});
+					return true;
+				}
+			}
+			return false;
+		}
+
+		// This method shows an example of using the BossChecklistBossInfo data for something cool in your mod.
+		public static float DownedBossedProgress() {
+			if (bossInfos.Count == 0) // bossInfos might be empty, if BossChecklist isn't present or something goes wrong.
+				return 0;
+
+			return (float)bossInfos.Count(x => x.Value.downed()) / bossInfos.Count();
+		}
+	}
+}
+*/

--- a/BossInfo.cs
+++ b/BossInfo.cs
@@ -32,6 +32,50 @@ namespace BossChecklist
 		internal bool hidden;
 		internal EntryType type;
 
+		/*
+		internal ExpandoObject ConvertToExpandoObject() {
+			dynamic expando = new ExpandoObject();
+
+			expando.key = Key;
+			expando.progression = progression;
+			//maybe make a hardmode = progression > 6f bool? or explain when a boss is hardmode on the wiki 
+			expando.displayName = name;
+			expando.npcIDs = new List<int>(npcIDs);
+			expando.downed = new Func<bool>(downed);
+
+			expando.isBoss = type.Equals(EntryType.Boss);
+			expando.isMiniboss = type.Equals(EntryType.MiniBoss);
+			expando.isEvent = type.Equals(EntryType.Event);
+
+			expando.spawnItem = new List<int>(spawnItem);
+			expando.loot = new List<int>(loot);
+			expando.collection = new List<int>(collection);
+
+			return expando;
+		}
+		*/
+
+		internal Dictionary<string, object> ConvertToDictionary() {
+			var dict = new Dictionary<string, object> {
+				{ "key", Key },
+				{ "progression", progression },
+				//maybe make a hardmode = progression > 6f bool? or explain when a boss is hardmode on the wiki 
+				{ "displayName", name },
+				{ "npcIDs", new List<int>(npcIDs) },
+				{ "downed", new Func<bool>(downed) },
+
+				{ "isBoss", type.Equals(EntryType.Boss) },
+				{ "isMiniboss", type.Equals(EntryType.MiniBoss) },
+				{ "isEvent", type.Equals(EntryType.Event) },
+
+				{ "spawnItem", new List<int>(spawnItem) },
+				{ "loot", new List<int>(loot) },
+				{ "collection", new List<int>(collection) }
+			};
+
+			return dict;
+		}
+
 		internal string SourceDisplayName => modSource == "Terraria" || modSource == "Unknown" ? modSource : ModLoader.GetMod(modSource).DisplayName;
 
 		internal BossInfo(EntryType type, float progression, string modSource, string name, List<int> npcIDs, Func<bool> downed, Func<bool> available, List<int> spawnItem, List<int> collection, List<int> loot, string pageTexture, string info, string despawnMessage = "", string overrideIconTexture = "") {

--- a/BossInfo.cs
+++ b/BossInfo.cs
@@ -37,16 +37,18 @@ namespace BossChecklist
 			dynamic expando = new ExpandoObject();
 
 			expando.key = Key;
-			expando.progression = progression;
-			//maybe make a hardmode = progression > 6f bool? or explain when a boss is hardmode on the wiki 
+			expando.modSource = modSource;
+			expando.internalName = internalName;
 			expando.displayName = name;
-			expando.npcIDs = new List<int>(npcIDs);
+
+			expando.progression = progression;
 			expando.downed = new Func<bool>(downed);
 
 			expando.isBoss = type.Equals(EntryType.Boss);
 			expando.isMiniboss = type.Equals(EntryType.MiniBoss);
 			expando.isEvent = type.Equals(EntryType.Event);
 
+			expando.npcIDs = new List<int>(npcIDs);
 			expando.spawnItem = new List<int>(spawnItem);
 			expando.loot = new List<int>(loot);
 			expando.collection = new List<int>(collection);
@@ -55,19 +57,23 @@ namespace BossChecklist
 		}
 		*/
 
-		internal Dictionary<string, object> ConvertToDictionary() {
+		internal Dictionary<string, object> ConvertToDictionary(Version GetBossInfoAPIVersion) {
+			// We may want to allow different returns based on api version.
+			//if (GetBossInfoAPIVersion == new Version(1, 1)) {
 			var dict = new Dictionary<string, object> {
 				{ "key", Key },
-				{ "progression", progression },
-				//maybe make a hardmode = progression > 6f bool? or explain when a boss is hardmode on the wiki 
+				{ "modSource", modSource },
 				{ "displayName", name },
-				{ "npcIDs", new List<int>(npcIDs) },
+				{ "internalName", internalName },
+
+				{ "progression", progression },
 				{ "downed", new Func<bool>(downed) },
 
 				{ "isBoss", type.Equals(EntryType.Boss) },
 				{ "isMiniboss", type.Equals(EntryType.MiniBoss) },
 				{ "isEvent", type.Equals(EntryType.Event) },
 
+				{ "npcIDs", new List<int>(npcIDs) },
 				{ "spawnItem", new List<int>(spawnItem) },
 				{ "loot", new List<int>(loot) },
 				{ "collection", new List<int>(collection) }

--- a/build.txt
+++ b/build.txt
@@ -1,5 +1,5 @@
 author = SheepishShepherd, jopojelly
-version = 1.0.13
+version = 1.1
 displayName = Boss Checklist
 homepage = http://forums.terraria.org/index.php?threads/boss-checklist-in-game-progression-checklist.50668/
 hideCode = false


### PR DESCRIPTION
Add mod.Call to expose the `bossTracker.SortedBosses` data to modders for use. Copy, so no way to modify the original data. Realized through a list of dictionaries with each key/value pair being a variable in the internal `BossInfo` class. Commented out was an `ExpandoObject` attempt that failed to compile, but left in due to request. Below is sample usage with a recommended class to hold these variables.
Feel free to change everything

Sample usage: https://pastebin.com/xWcUwWUJ