### PR TITLE
typo: "you enemy" -> "your enemy"

### DIFF
--- a/UIElements/BossLogUIElements.cs
+++ b/UIElements/BossLogUIElements.cs
@@ -811,7 +811,7 @@ namespace BossChecklist.UIElements
 											Main.hoverItemName = "Avoid as many attacks as you can!";
 										}
 										if (i == 3) {
-											Main.hoverItemName = "How close can you be to death and still defeat you enemy?";
+											Main.hoverItemName = "How close can you be to death and still defeat your enemy?";
 										}
 									}
 								}


### PR DESCRIPTION
There is a typo when looking at the records of a boss. Hovering over the lowest health state shows:

> "How close can you be to death and still defeat you enemy?"

but it should be:

> "How close can you be to death and still defeat **your** enemy?"