### PR TITLE
New mod calls for 1.4.4

### DIFF
--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -259,7 +259,8 @@ namespace BossChecklist
 
 			void SetupLocalizationForNPC(int npcType, string entryName, string spawnInfo, string despawnMessage) {
 				ModNPC modNPC = ModContent.GetModNPC(npcType);
-				modNPC.GetLocalization("BossChecklistIntegration.EntryName", () => GetLocalizationEntryValueFromObsoleteSubmission(entryName));
+				if(modNPC.DisplayName.Value != Language.GetTextValue(entryName)) // No need to register localization key if equal to displayname. Updated Call code will also assume similar logic.
+					modNPC.GetLocalization("BossChecklistIntegration.EntryName", () => GetLocalizationEntryValueFromObsoleteSubmission(entryName));
 				if(spawnInfo != null) // Required in 1.4.4, so register even if null.
 					modNPC.GetLocalization("BossChecklistIntegration.SpawnInfo", () => GetLocalizationEntryValueFromObsoleteSubmission(spawnInfo));
 				else

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -174,13 +174,13 @@ namespace BossChecklist
 					);
 					return "Success";
 				}
-				else if (message.StartsWith("Modify")) {
+				else if (message.StartsWith("Submit")) {
 					OrphanType? DetermineOrphanType() {
 						return message switch {
-							"ModifyEntryLoot" => OrphanType.Loot,
-							"ModifyEntryCollections" => OrphanType.Collection,
-							"ModifyEntrySpawnItems" => OrphanType.SpawnItem,
-							"ModifyEventNPCs" => OrphanType.EventNPC,
+							"SubmitEntryLoot" => OrphanType.Loot,
+							"SubmitEntryCollections" => OrphanType.Collection,
+							"SubmitEntrySpawnItems" => OrphanType.SpawnItem,
+							"SubmitEventNPCs" => OrphanType.EventNPC,
 							_ => null
 						};
 					}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -269,7 +269,7 @@ namespace BossChecklist
 					if (despawnMessage is string)
 						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => GetLocalizationEntryValueFromObsoleteSubmission(despawnMessage as string));
 					else if (despawnMessage is Func<NPC, string>)
-						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => "");
+						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => "{0} is no longer after you...");
 				}
 			}
 

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -193,7 +193,7 @@ namespace BossChecklist
 					Logger.Error($"Call Error: Unknown Message: {message}");
 
 					// Track old mod calls to later inform mod developers to update their mod calls.
-					if (message.Contains("AddBoss") || message.Contains("AddMiniboss") || message.Contains("AddEvent")) {
+					if (message.Contains("AddBoss") || message.Contains("AddMiniBoss") || message.Contains("AddEvent")) {
 						string bossName = "unknown";
 						if (args[1] is Mod) {
 							string translation = args[2] as string;

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -169,8 +169,7 @@ namespace BossChecklist
 						args[4] as LocalizedText, // Name Translation
 						InterpretObjectAsListOfInt(args[5]), // NPC IDs
 						args[6] as Func<bool>, // Downed
-						args[7] as LocalizedText, // Spawn Info
-						args[8] as Dictionary<string, object>
+						args[7] as Dictionary<string, object>
 					);
 					return "Success";
 				}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -150,7 +150,7 @@ namespace BossChecklist
 					throw new Exception($"Call Error: The attempted message, \"{message}\", was sent too late. BossChecklist expects Call messages up until before AddRecipes.");
 				
 				if (message == "LogBoss" || message == "LogMiniBoss" || message == "LogEvent") {
-					if (args[1] is not Mod) {
+					if (args[1] is not Mod submittedMod) {
 						Logger.Warn($"Invalid mod instance passed ({args[1] as string}). Your call must contain a Mod instance to generate an entry key.");
 						return "Failure";
 					}
@@ -163,7 +163,7 @@ namespace BossChecklist
 
 					bossTracker.AddEntry(
 						message == "LogBoss" ? EntryType.Boss : message == "LogMiniBoss" ? EntryType.MiniBoss : EntryType.Event,
-						args[1] as Mod, // Mod
+						submittedMod, // Mod
 						internalName, // Internal Name
 						Convert.ToSingle(args[3]), // Prog
 						args[4] as LocalizedText, // Name Translation
@@ -190,14 +190,14 @@ namespace BossChecklist
 						return "Failue";
 					}
 
-					if (args[1] is not Mod) {
+					if (args[1] is not Mod submittedMod) {
 						Logger.Error($"Invalid mod instance passed ({args[1] as string}). Your call must contain a Mod instance for logging purposes.");
 						return "Failure";
 					}
 
 					bossTracker.AddOrphanData(
 						DetermineOrphanType().Value, // OrphanType
-						args[1] as Mod,
+						submittedMod,
 						args[2] as Dictionary<string, object> // ID List
 					);
 
@@ -216,13 +216,11 @@ namespace BossChecklist
 					if (message.Contains("AddBoss") || message.Contains("AddMiniBoss") || message.Contains("AddEvent")) {
 						string bossName = "unknown";
 						if (args[1] is Mod) {
-							string translation = args[2] as string;
-							if (translation.StartsWith("$"))
-								translation = translation.Substring(1);
-							bossName = Language.GetTextValue(translation);
+							string submittedName = args[2] as string;
+							bossName = Language.GetTextValue(submittedName.StartsWith("$") ? submittedName.Substring(1) : submittedName);
 						}
-						else if (args[1] is string) {
-							bossName = args[1] as string;
+						else if (args[1] is string submittedName) {
+							bossName = submittedName;
 						}
 
 						bossTracker.AnyModHasOldCall = true;

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -153,8 +153,8 @@ namespace BossChecklist
 						submittedMod, // Mod
 						internalName, // Internal Name
 						Convert.ToSingle(args[3]), // Prog
-						InterpretObjectAsListOfInt(args[4]), // NPC IDs
-						args[5] as Func<bool>, // Downed
+						args[4] as Func<bool>, // Downed
+						InterpretObjectAsListOfInt(args[5]), // NPC IDs
 						args[6] as Dictionary<string, object>
 					);
 					return "Success";

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -21,17 +21,6 @@ namespace BossChecklist
 
 		public static Dictionary<int, int> itemToMusicReference;
 
-		// Mods that have been added manually
-		internal bool vanillaLoaded = true;
-		//internal bool thoriumLoaded;
-
-		// Mods that have been added natively, no longer need code here.
-		internal static bool tremorLoaded;
-		//internal bool bluemagicLoaded;
-		//internal bool joostLoaded;
-		//internal bool calamityLoaded;
-		//internal bool pumpkingLoaded;
-
 		internal static ClientConfiguration ClientConfig;
 		internal static DebugConfiguration DebugConfig;
 		internal static BossLogConfiguration BossLogConfig;
@@ -44,8 +33,6 @@ namespace BossChecklist
 			instance = this;
 			ToggleChecklistHotKey = KeybindLoader.RegisterKeybind(this, "ToggleChecklist", "P");
 			ToggleBossLog = KeybindLoader.RegisterKeybind(this, "ToggleLog", "L");
-
-			tremorLoaded = ModLoader.TryGetMod("Tremor", out Mod mod);
 
 			FieldInfo itemToMusicField = typeof(MusicLoader).GetField("itemToMusic", BindingFlags.Static | BindingFlags.NonPublic);
 			itemToMusicReference = (Dictionary<int, int>)itemToMusicField.GetValue(null);

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -267,7 +267,7 @@ namespace BossChecklist
 				if (despawnMessage != null) { // optional, don't register unless provided
 					if (despawnMessage is string)
 						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => GetLocalizationEntryValueFromObsoleteSubmission(despawnMessage as string));
-					else if (despawnMessage is Func<NPC, string> || despawnMessage is null)
+					else if (despawnMessage is Func<NPC, string>)
 						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => "{0} is no longer after you...");
 				}
 			}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -147,148 +147,30 @@ namespace BossChecklist
 					}
 					return "Failure";
 				}
+
 				if (bossTracker.EntriesFinalized)
 					throw new Exception($"Call Error: The attempted message, \"{message}\", was sent too late. BossChecklist expects Call messages up until before AddRecipes.");
-				if (message == "AddBoss" || message == "AddBossWithInfo") { // For compatability reasons
-					if (argsLength < 7) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[1] as string);
-						bossTracker.AddBoss(
-							args[1] as string, // Boss Name
-							Convert.ToSingle(args[2]), // Prog
-							args[3] as Func<bool>, // Downed
-							args[4] as string, // Info
-							args[5] as Func<bool> // Available
-						);
+				
+				if (message == "LogBoss" || message == "LogMiniBoss" || message == "LogEvent") {
+					string internalName = args[2] as string;
+					if (!internalName.Any(char.IsLetter)) {
+						Logger.Warn($"Invalid internal name passed. '{internalName}' contains whitespaces or non-alpha characters.");
+						return "Failure";
 					}
-					else if (args[1] as Mod == null) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[4] as string);
-						bossTracker.AddBoss(
-							args[3] as Mod, // Mod
-							args[4] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[2]), // IDs
-							Convert.ToSingle(args[1]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[13] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[6]), // Spawn Items
-							args[9] as string // Spawn Info
-						);
-					}
-					else {
-						bossTracker.AddBoss(
-							args[1] as Mod, // Mod
-							args[2] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[3]), // IDs
-							Convert.ToSingle(args[4]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[6] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[8]), // Spawn Items
-							args[9] as string, // Spawn Info
-							InterpretObjectAsStringFunction(args[10]), // Despawn message
-							args[11] as Action<SpriteBatch, Rectangle, Color>, // Custom Drawing
-							InterpretObjectAsListOfStrings(args[12])
-						);
-					}
+
+					bossTracker.AddEntry(
+						message == "LogBoss" ? EntryType.Boss : message == "LogMiniBoss" ? EntryType.MiniBoss : EntryType.Event,
+						args[1] as Mod, // Mod
+						internalName, // Internal Name
+						Convert.ToSingle(args[3]), // Prog
+						args[4] as LocalizedText, // Name Translation
+						InterpretObjectAsListOfInt(args[5]), // NPC IDs
+						args[6] as Func<bool>, // Downed
+						args[7] as LocalizedText, // Spawn Info
+						args[8] as Dictionary<string, object>
+					);
 					return "Success";
 				}
-				else if (message == "AddMiniBoss" || message == "AddMiniBossWithInfo") {
-					if (argsLength < 7) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[1] as string);
-						bossTracker.AddMiniBoss(
-							args[1] as string, // MiniBoss Name
-							Convert.ToSingle(args[2]), // Prog
-							args[3] as Func<bool>, // Downed
-							args[4] as string, // Info
-							args[5] as Func<bool> // Available
-						);
-					}
-					else if (args[1] as Mod == null) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[4] as string);
-						bossTracker.AddMiniBoss(
-							args[3] as Mod, // Mod
-							args[4] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[2]), // IDs
-							Convert.ToSingle(args[1]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[13] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[6]), // Spawn Items
-							args[9] as string // Spawn Info
-						);
-					}
-					else {
-						bossTracker.AddMiniBoss(
-							args[1] as Mod, // Mod
-							args[2] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[3]), // IDs
-							Convert.ToSingle(args[4]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[6] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[8]), // Spawn Items
-							args[9] as string, // Spawn Info
-							InterpretObjectAsStringFunction(args[10]), // Despawn message
-							args[11] as Action<SpriteBatch, Rectangle, Color>, // Custom Drawing
-							InterpretObjectAsListOfStrings(args[12])
-						);
-					}
-					return "Success";
-				}
-				else if (message == "AddEvent" || message == "AddEventWithInfo") {
-					if (argsLength < 7) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[1] as string);
-						bossTracker.AddEvent(
-							args[1] as string, // Event Name
-							Convert.ToSingle(args[2]), // Prog
-							args[3] as Func<bool>, // Downed
-							args[4] as string, // Info
-							args[5] as Func<bool> // Available
-						);
-					}
-					else if (args[1] as Mod == null) {
-						bossTracker.AnyModHasOldCall = true;
-						AddToOldCalls(message, args[4] as string);
-						bossTracker.AddEvent(
-							args[3] as Mod, // Mod
-							args[4] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[2]), // IDs
-							Convert.ToSingle(args[1]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[13] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[6]), // Spawn Items
-							args[9] as string // Spawn Info
-						);
-					}
-					else {
-						bossTracker.AddEvent(
-							args[1] as Mod, // Mod
-							args[2] as string, // Boss Name
-							InterpretObjectAsListOfInt(args[3]), // IDs
-							Convert.ToSingle(args[4]), // Prog
-							args[5] as Func<bool>, // Downed
-							args[6] as Func<bool>, // Available
-							InterpretObjectAsListOfInt(args[7]), // Collection
-							InterpretObjectAsListOfInt(args[8]), // Spawn Items
-							args[9] as string, // Spawn Info
-							args[10] as Action<SpriteBatch, Rectangle, Color>, // Custom Drawing
-							InterpretObjectAsListOfStrings(args[11])
-						);
-					}
-					return "Success";
-				}
-				// TODO
-				//else if (message == "GetCurrentBossStates")
-				//{
-				//	// Returns List<Tuple<string, float, int, bool>>: Name, value, bosstype(boss, miniboss, event), downed.
-				//	return bossTracker.allBosses.Select(x => new Tuple<string, float, int, bool>(x.name, x.progression, (int)x.type, x.downed())).ToList();
-				//}
 				else if (message == "AddToBossLoot" || message == "AddToBossCollection" || message == "AddToBossSpawnItems" || message == "AddToEventNPCs") {
 					bossTracker.AddOrphanData(
 						message, // OrphanType
@@ -301,8 +183,31 @@ namespace BossChecklist
 					}
 					return "Success";
 				}
+				// TODO
+				//else if (message == "GetCurrentBossStates")
+				//{
+				//	// Returns List<Tuple<string, float, int, bool>>: Name, value, bosstype(boss, miniboss, event), downed.
+				//	return bossTracker.allBosses.Select(x => new Tuple<string, float, int, bool>(x.name, x.progression, (int)x.type, x.downed())).ToList();
+				//}
 				else {
 					Logger.Error($"Call Error: Unknown Message: {message}");
+
+					// Track old mod calls to later inform mod developers to update their mod calls.
+					if (message.Contains("AddBoss") || message.Contains("AddMiniboss") || message.Contains("AddEvent")) {
+						string bossName = "unknown";
+						if (args[1] is Mod) {
+							string translation = args[2] as string;
+							if (translation.StartsWith("$"))
+								translation = translation.Substring(1);
+							bossName = Language.GetTextValue(translation);
+						}
+						else if (args[1] is string) {
+							bossName = args[1] as string;
+						}
+
+						bossTracker.AnyModHasOldCall = true;
+						AddToOldCalls(message, bossName);
+					}
 				}
 			}
 			catch (Exception e) {

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -268,7 +268,7 @@ namespace BossChecklist
 				if (despawnMessage != null) { // optional, don't register unless provided
 					if (despawnMessage is string)
 						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => GetLocalizationEntryValueFromObsoleteSubmission(despawnMessage as string));
-					else if (despawnMessage is Func<NPC, string>)
+					else if (despawnMessage is Func<NPC, string> || despawnMessage is null)
 						modNPC.GetLocalization("BossChecklistIntegration.DespawnMessage", () => "{0} is no longer after you...");
 				}
 			}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -153,10 +153,9 @@ namespace BossChecklist
 						submittedMod, // Mod
 						internalName, // Internal Name
 						Convert.ToSingle(args[3]), // Prog
-						args[4] as LocalizedText, // Name Translation
-						InterpretObjectAsListOfInt(args[5]), // NPC IDs
-						args[6] as Func<bool>, // Downed
-						args[7] as Dictionary<string, object>
+						InterpretObjectAsListOfInt(args[4]), // NPC IDs
+						args[5] as Func<bool>, // Downed
+						args[6] as Dictionary<string, object>
 					);
 					return "Success";
 				}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -152,9 +152,14 @@ namespace BossChecklist
 					throw new Exception($"Call Error: The attempted message, \"{message}\", was sent too late. BossChecklist expects Call messages up until before AddRecipes.");
 				
 				if (message == "LogBoss" || message == "LogMiniBoss" || message == "LogEvent") {
+					if (args[1] is not Mod) {
+						Logger.Warn($"Invalid mod instance passed ({args[1] as string}). Your call must contain a Mod instance to generate an entry key.");
+						return "Failure";
+					}
+
 					string internalName = args[2] as string;
 					if (!internalName.Any(char.IsLetter)) {
-						Logger.Warn($"Invalid internal name passed. '{internalName}' contains whitespaces or non-alpha characters.");
+						Logger.Warn($"Invalid internal name passed ({internalName}). Your call must contain a string without whitespaces or any non-alpha characters to generate an entry key.");
 						return "Failure";
 					}
 

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -176,16 +174,33 @@ namespace BossChecklist
 					);
 					return "Success";
 				}
-				else if (message == "AddToBossLoot" || message == "AddToBossCollection" || message == "AddToBossSpawnItems" || message == "AddToEventNPCs") {
-					bossTracker.AddOrphanData(
-						message, // OrphanType
-						args[1] as string, // Boss Key (obtainable via the BossLog, when display config is enabled)
-						InterpretObjectAsListOfInt(args[2]) // ID List
-					);
-					if (argsLength != 3) {
-						if (DebugConfig.ModCallLogVerbose)
-							Logger.Warn($"{message} mod call from the above mod is structured improperly. Mod developers can refer to link below:\n https://github.com/JavidPack/BossChecklist/wiki/[1.4]-Other-Mod-Calls");
+				else if (message.StartsWith("Modify")) {
+					OrphanType? DetermineOrphanType() {
+						return message switch {
+							"ModifyEntryLoot" => OrphanType.Loot,
+							"ModifyEntryCollections" => OrphanType.Collection,
+							"ModifyEntrySpawnItems" => OrphanType.SpawnItem,
+							"ModifyEventNPCs" => OrphanType.EventNPC,
+							_ => null
+						};
 					}
+
+					if (DetermineOrphanType() == null) {
+						Logger.Error($"Call Error: Unknown Message: {message}");
+						return "Failue";
+					}
+
+					if (args[1] is not Mod) {
+						Logger.Error($"Invalid mod instance passed ({args[1] as string}). Your call must contain a Mod instance for logging purposes.");
+						return "Failure";
+					}
+
+					bossTracker.AddOrphanData(
+						DetermineOrphanType().Value, // OrphanType
+						args[1] as Mod,
+						args[2] as Dictionary<string, object> // ID List
+					);
+
 					return "Success";
 				}
 				// TODO

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -156,7 +156,7 @@ namespace BossChecklist
 					}
 
 					string internalName = args[2] as string;
-					if (!internalName.Any(char.IsLetter)) {
+					if (!internalName.All(char.IsLetter)) {
 						Logger.Warn($"Invalid internal name passed ({internalName}). Your call must contain a string without whitespaces or any non-alpha characters to generate an entry key.");
 						return "Failure";
 					}

--- a/BossChecklist.cs
+++ b/BossChecklist.cs
@@ -143,8 +143,8 @@ namespace BossChecklist
 					}
 
 					string internalName = args[2] as string;
-					if (!internalName.All(char.IsLetter)) {
-						Logger.Warn($"Invalid internal name passed ({internalName}). Your call must contain a string without whitespaces or any non-alpha characters to generate an entry key.");
+					if (!internalName.All(char.IsLetterOrDigit)) {
+						Logger.Warn($"Invalid internal name passed ({internalName}). Your call must contain a string comprised of letters and/or digits without whitespace characters in order to generate an entry key.");
 						return "Failure";
 					}
 

--- a/BossChecklistIntegrationExample.cs
+++ b/BossChecklistIntegrationExample.cs
@@ -58,7 +58,7 @@ namespace <YourModsNamespace>
 						isEvent = boss.Value.ContainsKey("isEvent") ? Convert.ToBoolean(boss.Value["isEvent"]) : false,
 
 						npcIDs = boss.Value.ContainsKey("npcIDs") ? boss.Value["npcIDs"] as List<int> : new List<int>(),
-						spawnItem = boss.Value.ContainsKey("spawnItem") ? boss.Value["spawnItem"] as List<int> : new List<int>(),
+						spawnItem = boss.Value.ContainsKey("spawnItems") ? boss.Value["spawnItems"] as List<int> : new List<int>(),
 						loot = boss.Value.ContainsKey("loot") ? boss.Value["loot"] as List<int> : new List<int>(),
 						collection = boss.Value.ContainsKey("collection") ? boss.Value["collection"] as List<int> : new List<int>(),
 					});

--- a/BossChecklistIntegrationExample.cs
+++ b/BossChecklistIntegrationExample.cs
@@ -17,9 +17,8 @@ namespace <YourModsNamespace>
 
 		public class BossChecklistBossInfo
 		{
-			internal string key = ""; // equal to "modSource internalName"
+			internal string key = ""; // unique identifier for an entry
 			internal string modSource = "";
-			internal string internalName = "";
 			internal string displayName = "";
 
 			internal float progression = 0f; // See https://github.com/JavidPack/BossChecklist/blob/master/BossTracker.cs#L13 for vanilla boss values
@@ -49,7 +48,6 @@ namespace <YourModsNamespace>
 					bossInfos = bossInfoList.ToDictionary(boss => boss.Key, boss => new BossChecklistBossInfo() {
 						key = boss.Value.ContainsKey("key") ? boss.Value["key"] as string : "",
 						modSource = boss.Value.ContainsKey("modSource") ? boss.Value["modSource"] as string : "",
-						internalName = boss.Value.ContainsKey("internalName") ? boss.Value["internalName"] as string : "",
 						displayName = boss.Value.ContainsKey("displayName") ? boss.Value["displayName"] as string : "",
 
 						progression = boss.Value.ContainsKey("progression") ? Convert.ToSingle(boss.Value["progression"]) : 0f,

--- a/BossChecklistIntegrationExample.cs
+++ b/BossChecklistIntegrationExample.cs
@@ -13,7 +13,7 @@ namespace <YourModsNamespace>
 	{
 		// Boss Checklist might add new features, so a version is passed into GetBossInfo. 
 		// If a new version of the GetBossInfo Call is implemented, find this class in the Boss Checklist Github once again and replace this version with the new version: https://github.com/JavidPack/BossChecklist/blob/master/BossChecklistIntegrationExample.cs
-		private static readonly Version BossChecklistAPIVersion = new Version(1, 1); // Do not change this yourself.
+		private static readonly Version BossChecklistAPIVersion = new Version(1, 6); // Do not change this yourself.
 
 		public class BossChecklistBossInfo
 		{

--- a/BossLogUI.cs
+++ b/BossLogUI.cs
@@ -981,8 +981,8 @@ namespace BossChecklist
 					PageTwo.Append(lootButton);
 				}
 				else {
-					// if the boss has an unknown source, it is likely that the mod call for it is using the old mod call
-					// this should be brought to the developer's attention, so a message will be displayed on the boss's page
+					// Old mod calls are no longer supported and will not add entries
+					// if somehow the entry has an unknown source, make a panel to show something went wrong
 					UIPanel brokenPanel = new UIPanel();
 					brokenPanel.Height.Pixels = 160;
 					brokenPanel.Width.Pixels = 340;
@@ -990,10 +990,7 @@ namespace BossChecklist
 					brokenPanel.Left.Pixels = 3;
 					PageTwo.Append(brokenPanel);
 
-					// TODO: this will likely always output the NotImplemented, but I don't want to remove it just yet
-					bool entryHasOldCall = BossChecklist.bossTracker.OldCalls.Values.Any(x => x.Contains(GetLogEntryInfo.name));
-					string message = entryHasOldCall ? "NotImplemented" : "LogFeaturesNotAvailable";
-					FittedTextPanel brokenDisplay = new FittedTextPanel($"{LangLog}.EntryPage.{message}");
+					FittedTextPanel brokenDisplay = new FittedTextPanel($"{LangLog}.EntryPage.LogFeaturesNotAvailable");
 					brokenDisplay.Height.Pixels = 200;
 					brokenDisplay.Width.Pixels = 340;
 					brokenDisplay.Top.Pixels = -12;

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -1089,9 +1089,9 @@ namespace BossChecklist
 			ItemID.MusicBoxOWHallow,
 		};
 
-		internal void AddEntry(EntryType type, Mod mod, string iName, float val, List<int> id, Func<bool> down, Dictionary<string, object> extra = null) {
+		internal void AddEntry(EntryType type, Mod mod, string iName, float val, Func<bool> down, List<int> id, Dictionary<string, object> extra = null) {
 			EnsureBossIsNotDuplicate(mod?.Name ?? "Unknown", iName);
-			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, id, down, extra));
+			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, down, id, extra));
 			LogNewBoss(mod?.Name ?? "Unknown", iName);
 		}
 

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -1089,9 +1089,9 @@ namespace BossChecklist
 			ItemID.MusicBoxOWHallow,
 		};
 
-		internal void AddEntry(EntryType type, Mod mod, string iName, float val, LocalizedText name, List<int> id, Func<bool> down, LocalizedText info, Dictionary<string, object> extra = null) {
+		internal void AddEntry(EntryType type, Mod mod, string iName, float val, LocalizedText name, List<int> id, Func<bool> down, Dictionary<string, object> extra = null) {
 			EnsureBossIsNotDuplicate(mod?.Name ?? "Unknown", iName);
-			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, name, id, down, info, extra));
+			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, name, id, down, extra));
 			LogNewBoss(mod?.Name ?? "Unknown", iName);
 		}
 

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -79,96 +79,96 @@ namespace BossChecklist
 		private void InitializeVanillaEntries() {
 			SortedEntries = new List<EntryInfo> {
 				// Bosses -- Vanilla
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, KingSlime, "$NPCName.KingSlime", new List<int>() { NPCID.KingSlime }, () => NPC.downedSlimeKing, new List<int>() { ItemID.SlimeCrown })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, KingSlime, "NPCName.KingSlime", NPCID.KingSlime, () => NPC.downedSlimeKing)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.KingSlime}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, EyeOfCthulhu, "$NPCName.EyeofCthulhu", new List<int>() { NPCID.EyeofCthulhu }, () => NPC.downedBoss1, new List<int>() { ItemID.SuspiciousLookingEye }),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, EaterOfWorlds, "$NPCName.EaterofWorldsHead", new List<int>() { NPCID.EaterofWorldsHead, NPCID.EaterofWorldsBody, NPCID.EaterofWorldsTail }, () => NPC.downedBoss2, new List<int>() { ItemID.WormFood })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, EyeOfCthulhu, "NPCName.EyeofCthulhu", NPCID.EyeofCthulhu, () => NPC.downedBoss1),
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, EaterOfWorlds, "NPCName.EaterofWorldsHead", new List<int>() { NPCID.EaterofWorldsHead, NPCID.EaterofWorldsBody, NPCID.EaterofWorldsTail }, () => NPC.downedBoss2)
 					.WithCustomAvailability(() => !WorldGen.crimson || Main.drunkWorld || ModLoader.TryGetMod("BothEvils", out Mod mod))
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.EaterofWorldsHead}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, EaterOfWorlds, "$NPCName.BrainofCthulhu", new List<int>() { NPCID.BrainofCthulhu }, () => NPC.downedBoss2, new List<int>() { ItemID.BloodySpine })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, EaterOfWorlds, "NPCName.BrainofCthulhu", NPCID.BrainofCthulhu, () => NPC.downedBoss2)
 					.WithCustomAvailability(() => WorldGen.crimson || Main.drunkWorld || ModLoader.TryGetMod("BothEvils", out Mod mod)),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, QueenBee, "$NPCName.QueenBee", new List<int>() { NPCID.QueenBee }, () => NPC.downedQueenBee, new List<int>() { ItemID.Abeemination }),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, Skeletron, "$NPCName.SkeletronHead", new List<int>() { NPCID.SkeletronHead, NPCID.SkeletronHand }, () => NPC.downedBoss3, new List<int>() { ItemID.ClothierVoodooDoll })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, QueenBee, "NPCName.QueenBee", NPCID.QueenBee, () => NPC.downedQueenBee),
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, Skeletron, "NPCName.SkeletronHead", new List<int>() { NPCID.SkeletronHead, NPCID.SkeletronHand }, () => NPC.downedBoss3)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.SkeletronHead}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, DeerClops, "$NPCName.Deerclops", new List<int>() { NPCID.Deerclops }, () => NPC.downedDeerclops, new List<int>() { ItemID.DeerThing })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, DeerClops, "NPCName.Deerclops", NPCID.Deerclops, () => NPC.downedDeerclops)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.Deerclops}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, WallOfFlesh, "$NPCName.WallofFlesh", new List<int>() { NPCID.WallofFlesh, NPCID.WallofFleshEye }, () => Main.hardMode, new List<int>() { ItemID.GuideVoodooDoll })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, WallOfFlesh, "NPCName.WallofFlesh", new List<int>() { NPCID.WallofFlesh, NPCID.WallofFleshEye }, () => Main.hardMode)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.WallofFlesh}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, QueenSlime, "$NPCName.QueenSlimeBoss", new List<int>() { NPCID.QueenSlimeBoss }, () => NPC.downedQueenSlime, new List<int>() { ItemID.QueenSlimeCrystal })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, QueenSlime, "NPCName.QueenSlimeBoss", NPCID.QueenSlimeBoss, () => NPC.downedQueenSlime)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.QueenSlimeBoss}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, TheTwins, "$Enemies.TheTwins", new List<int>() { NPCID.Retinazer, NPCID.Spazmatism }, () => NPC.downedMechBoss2, new List<int>() { ItemID.MechanicalEye })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, TheTwins, "Enemies.TheTwins", new List<int>() { NPCID.Retinazer, NPCID.Spazmatism }, () => NPC.downedMechBoss2)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.Retinazer}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, TheDestroyer, "$NPCName.TheDestroyer", new List<int>() { NPCID.TheDestroyer }, () => NPC.downedMechBoss1, new List<int>() { ItemID.MechanicalWorm })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, TheDestroyer, "NPCName.TheDestroyer", NPCID.TheDestroyer, () => NPC.downedMechBoss1)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.TheDestroyer}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, SkeletronPrime, "$NPCName.SkeletronPrime", new List<int>() { NPCID.SkeletronPrime }, () => NPC.downedMechBoss3, new List<int>() { ItemID.MechanicalSkull })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, SkeletronPrime, "NPCName.SkeletronPrime", NPCID.SkeletronPrime, () => NPC.downedMechBoss3)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.SkeletronPrime}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, Plantera, "$NPCName.Plantera", new List<int>() { NPCID.Plantera }, () => NPC.downedPlantBoss, new List<int>() { }),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, Golem, "$NPCName.Golem", new List<int>() { NPCID.Golem, NPCID.GolemHead }, () => NPC.downedGolemBoss, new List<int>() { ItemID.LihzahrdPowerCell, ItemID.LihzahrdAltar })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, Plantera, "NPCName.Plantera", NPCID.Plantera, () => NPC.downedPlantBoss),
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, Golem, "NPCName.Golem", new List<int>() { NPCID.Golem, NPCID.GolemHead }, () => NPC.downedGolemBoss)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.Golem}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, Betsy, "$NPCName.DD2Betsy", new List<int>() { NPCID.DD2Betsy }, () => WorldAssist.downedInvasionT3Ours, new List<int>() { ItemID.DD2ElderCrystal, ItemID.DD2ElderCrystalStand })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, Betsy, "NPCName.DD2Betsy", NPCID.DD2Betsy, () => WorldAssist.downedInvasionT3Ours)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.DD2Betsy}"),
 					// No despawn message due to being in an event
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, EmpressOfLight, "$NPCName.HallowBoss", new List<int>() { NPCID.HallowBoss }, () => NPC.downedEmpressOfLight, new List<int>() { ItemID.EmpressButterfly })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, EmpressOfLight, "NPCName.HallowBoss", NPCID.HallowBoss, () => NPC.downedEmpressOfLight)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.HallowBoss}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, DukeFishron, "$NPCName.DukeFishron", new List<int>() { NPCID.DukeFishron }, () => NPC.downedFishron, new List<int>() { ItemID.TruffleWorm }),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, LunaticCultist, "$NPCName.CultistBoss", new List<int>() { NPCID.CultistBoss }, () => NPC.downedAncientCultist, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, DukeFishron, "NPCName.DukeFishron", NPCID.DukeFishron, () => NPC.downedFishron),
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, LunaticCultist, "NPCName.CultistBoss", NPCID.CultistBoss, () => NPC.downedAncientCultist)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.CultistBoss}"),
-				EntryInfo.MakeVanillaBoss(EntryType.Boss, Moonlord, "$Enemies.MoonLord", new List<int>() { NPCID.MoonLordHead, NPCID.MoonLordCore, NPCID.MoonLordHand }, () => NPC.downedMoonlord, new List<int>() { ItemID.CelestialSigil })
+				EntryInfo.MakeVanillaBoss(EntryType.Boss, Moonlord, "Enemies.MoonLord", new List<int>() { NPCID.MoonLordHead, NPCID.MoonLordCore, NPCID.MoonLordHand }, () => NPC.downedMoonlord)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.MoonLordHead}"),
 
 				// Minibosses and Events -- Vanilla
-				EntryInfo.MakeVanillaEvent(TorchGod, "$NPCName.TorchGod", () => WorldAssist.downedTorchGod, new List<int>() { ItemID.Torch })
+				EntryInfo.MakeVanillaEvent(TorchGod, "NPCName.TorchGod", () => WorldAssist.downedTorchGod)
 					.WithCustomHeadIcon($"Terraria/Images/Item_{ItemID.TorchGodsFavor}"),
-				EntryInfo.MakeVanillaEvent(BloodMoon, "$Bestiary_Events.BloodMoon", () => WorldAssist.downedBloodMoon, new List<int>() { ItemID.BloodMoonStarter })
+				EntryInfo.MakeVanillaEvent(BloodMoon, "Bestiary_Events.BloodMoon", () => WorldAssist.downedBloodMoon)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventBloodMoon")
 					.WithCustomHeadIcon($"BossChecklist/Resources/BossTextures/EventBloodMoon_Head"),
 				// EntryInfo.MakeVanillaBoss(BossChecklistType.MiniBoss,WallOfFlesh + 0.1f, "Clown", new List<int>() { NPCID.Clown}, () => NPC.downedClown, new List<int>() { }, $"Spawns during Hardmode Bloodmoon"),
-				EntryInfo.MakeVanillaEvent(GoblinArmy, "Goblin Army", () => NPC.downedGoblins, new List<int>() { ItemID.GoblinBattleStandard })
-					.WithCustomTranslationKey("$LegacyInterface.88")
+				EntryInfo.MakeVanillaEvent(GoblinArmy, "Goblin Army", () => NPC.downedGoblins)
+					.WithCustomTranslationKey("LegacyInterface.88")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventGoblinArmy")
 					.WithCustomHeadIcon("Terraria/Images/Extra_9"),
-				EntryInfo.MakeVanillaEvent(OldOnesArmy, "Old One's Army", () => Terraria.GameContent.Events.DD2Event.DownedInvasionAnyDifficulty, new List<int>() { ItemID.DD2ElderCrystal, ItemID.DD2ElderCrystalStand })
-					.WithCustomTranslationKey("$DungeonDefenders2.InvasionProgressTitle")
+				EntryInfo.MakeVanillaEvent(OldOnesArmy, "Old One's Army", () => Terraria.GameContent.Events.DD2Event.DownedInvasionAnyDifficulty)
+					.WithCustomTranslationKey("DungeonDefenders2.InvasionProgressTitle")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventOldOnesArmy")
 					.WithCustomHeadIcon("Terraria/Images/Extra_79"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, DarkMage, "$NPCName.DD2DarkMageT3", new List<int>() { NPCID.DD2DarkMageT3 }, () => WorldAssist.downedDarkMage, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, DarkMage, "NPCName.DD2DarkMageT3", new List<int>() { NPCID.DD2DarkMageT3 }, () => WorldAssist.downedDarkMage)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.DD2DarkMageT3}"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Ogre, "$NPCName.DD2OgreT3", new List<int>() { NPCID.DD2OgreT3 }, () => WorldAssist.downedOgre, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Ogre, "NPCName.DD2OgreT3", new List<int>() { NPCID.DD2OgreT3 }, () => WorldAssist.downedOgre)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.DD2OgreT3}"),
-				EntryInfo.MakeVanillaEvent(FrostLegion, "Frost Legion", () => NPC.downedFrost, new List<int>() { ItemID.SnowGlobe })
-					.WithCustomTranslationKey("$LegacyInterface.87")
+				EntryInfo.MakeVanillaEvent(FrostLegion, "Frost Legion", () => NPC.downedFrost)
+					.WithCustomTranslationKey("LegacyInterface.87")
 					.WithCustomAvailability(() => Main.xMas)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventFrostLegion")
 					.WithCustomHeadIcon("Terraria/Images/Extra_7"),
-				EntryInfo.MakeVanillaEvent(PirateInvasion, "Pirate Invasion", () => NPC.downedPirates, new List<int>() { ItemID.PirateMap })
-					.WithCustomTranslationKey("$LegacyInterface.86")
+				EntryInfo.MakeVanillaEvent(PirateInvasion, "Pirate Invasion", () => NPC.downedPirates)
+					.WithCustomTranslationKey("LegacyInterface.86")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventPirateInvasion")
 					.WithCustomHeadIcon("Terraria/Images/Extra_11"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, PirateShip, "$NPCName.PirateShip", new List<int>() { NPCID.PirateShip }, () => WorldAssist.downedFlyingDutchman, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, PirateShip, "NPCName.PirateShip", new List<int>() { NPCID.PirateShip }, () => WorldAssist.downedFlyingDutchman)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.PirateShip}"),
-				EntryInfo.MakeVanillaEvent(SolarEclipse, "$Bestiary_Events.Eclipse", () => WorldAssist.downedSolarEclipse, new List<int>() { ItemID.SolarTablet })
+				EntryInfo.MakeVanillaEvent(SolarEclipse, "Bestiary_Events.Eclipse", () => WorldAssist.downedSolarEclipse)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventSolarEclipse")
 					.WithCustomHeadIcon($"BossChecklist/Resources/BossTextures/EventSolarEclipse_Head"),
-				EntryInfo.MakeVanillaEvent(PumpkinMoon, "Pumpkin Moon", () => WorldAssist.downedPumpkinMoon, new List<int>() { ItemID.PumpkinMoonMedallion })
-					.WithCustomTranslationKey("$LegacyInterface.84")
+				EntryInfo.MakeVanillaEvent(PumpkinMoon, "Pumpkin Moon", () => WorldAssist.downedPumpkinMoon)
+					.WithCustomTranslationKey("LegacyInterface.84")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventPumpkinMoon")
 					.WithCustomHeadIcon($"Terraria/Images/Extra_12"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, MourningWood, "$NPCName.MourningWood", new List<int>() { NPCID.MourningWood }, () => NPC.downedHalloweenTree, new List<int>() { }),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Pumpking, "$NPCName.Pumpking", new List<int>() { NPCID.Pumpking }, () => NPC.downedHalloweenKing, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, MourningWood, "NPCName.MourningWood", new List<int>() { NPCID.MourningWood }, () => NPC.downedHalloweenTree),
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Pumpking, "NPCName.Pumpking", new List<int>() { NPCID.Pumpking }, () => NPC.downedHalloweenKing)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/Boss{NPCID.Pumpking}"),
-				EntryInfo.MakeVanillaEvent(FrostMoon, "Frost Moon", () => WorldAssist.downedFrostMoon, new List<int>() { ItemID.NaughtyPresent })
-					.WithCustomTranslationKey("$LegacyInterface.83")
+				EntryInfo.MakeVanillaEvent(FrostMoon, "Frost Moon", () => WorldAssist.downedFrostMoon)
+					.WithCustomTranslationKey("LegacyInterface.83")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventFrostMoon")
 					.WithCustomHeadIcon($"Terraria/Images/Extra_8"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Everscream, "$NPCName.Everscream", new List<int>() { NPCID.Everscream }, () => NPC.downedChristmasTree, new List<int>() { }),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, SantaNK1, "$NPCName.SantaNK1", new List<int>() { NPCID.SantaNK1 }, () => NPC.downedChristmasSantank, new List<int>() { }),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, IceQueen, "$NPCName.IceQueen", new List<int>() { NPCID.IceQueen }, () => NPC.downedChristmasIceQueen, new List<int>() { }),
-				EntryInfo.MakeVanillaEvent(MartianMadness, "Martian Madness", () => NPC.downedMartians, new List<int>() { })
-					.WithCustomTranslationKey("$LegacyInterface.85")
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, Everscream, "NPCName.Everscream", new List<int>() { NPCID.Everscream }, () => NPC.downedChristmasTree),
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, SantaNK1, "NPCName.SantaNK1", new List<int>() { NPCID.SantaNK1 }, () => NPC.downedChristmasSantank),
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, IceQueen, "NPCName.IceQueen", new List<int>() { NPCID.IceQueen }, () => NPC.downedChristmasIceQueen),
+				EntryInfo.MakeVanillaEvent(MartianMadness, "Martian Madness", () => NPC.downedMartians)
+					.WithCustomTranslationKey("LegacyInterface.85")
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventMartianMadness")
 					.WithCustomHeadIcon($"Terraria/Images/Extra_10"),
-				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, MartianSaucer, "$NPCName.MartianSaucer", new List<int>() { NPCID.MartianSaucer, NPCID.MartianSaucerCore }, () => WorldAssist.downedMartianSaucer, new List<int>() { }),
-				EntryInfo.MakeVanillaEvent(LunarEvent, "Lunar Event", () => NPC.downedTowers, new List<int>() { })
+				EntryInfo.MakeVanillaBoss(EntryType.MiniBoss, MartianSaucer, "NPCName.MartianSaucer", new List<int>() { NPCID.MartianSaucer, NPCID.MartianSaucerCore }, () => WorldAssist.downedMartianSaucer),
+				EntryInfo.MakeVanillaEvent(LunarEvent, "Lunar Event", () => NPC.downedTowers)
 					.WithCustomPortrait($"BossChecklist/Resources/BossTextures/EventLunarEvent")
 					.WithCustomHeadIcon(new List<string>() {
 						$"Terraria/Images/NPC_Head_Boss_{NPCID.Sets.BossHeadTextures[NPCID.LunarTowerNebula]}",
@@ -278,10 +278,14 @@ namespace BossChecklist
 			EntriesFinalized = true;
 			if (AnyModHasOldCall) {
 				foreach (var oldCall in OldCalls) {
-					BossChecklist.instance.Logger.Info($"{oldCall.Key} calls for the following either not utilizing Boss Log features or is using an old call method for it. Mod developers should update mod calls with proper information to improve user experience. {oldCall.Key} entries include: [{string.Join(", ", oldCall.Value)}]");
+					string entryType = oldCall.Key.Substring(3);
+					if (entryType.EndsWith("WithInfo"))
+						entryType = entryType.Substring(0, entryType.Length - "WithInfo".Length);
+
+					BossChecklist.instance.Logger.Info($"The '{oldCall.Key}' call is an old call and is now obsolete. Use 'Log{entryType}' instead. {oldCall.Key} entries include: [{string.Join(", ", oldCall.Value)}]");
 				}
 				OldCalls.Clear();
-				BossChecklist.instance.Logger.Info("Updated Mod.Call documentation for BossChecklist can be found here: https://github.com/JavidPack/BossChecklist/wiki/%5B1.4-alpha%5D-Mod-Call-Structure");
+				BossChecklist.instance.Logger.Info("Updated Mod.Call documentation for BossChecklist can be found here: https://github.com/JavidPack/BossChecklist/wiki/[1.4.4]-Boss-Log-Entry-Mod-Call");
 			}
 
 			// The server must populate for collected records after all entries have been counted and sorted.
@@ -406,10 +410,48 @@ namespace BossChecklist
 			}
 		}
 
-		internal readonly Dictionary<string, List<int>> BossCollections = new Dictionary<string, List<int>>() {
+		internal readonly Dictionary<string, List<int>> EntrySpawnItems = new Dictionary<string, List<int>>() {
+			#region Boss SpawnItems
+			{ "Terraria KingSlime", new List<int>() { ItemID.SlimeCrown } },
+			{ "Terraria EyeofCthulhu", new List<int>() { ItemID.SuspiciousLookingEye } },
+			{ "Terraria EaterofWorldsHead", new List<int>() { ItemID.WormFood } },
+			{ "Terraria BrainofCthulhu", new List<int>() { ItemID.BloodySpine } },
+			{ "Terraria QueenBee", new List<int>() { ItemID.Abeemination } },
+			{ "Terraria SkeletronHead", new List<int>() { ItemID.ClothierVoodooDoll } },
+			{ "Terraria Deerclops", new List<int>() { ItemID.DeerThing } },
+			{ "Terraria WallofFlesh", new List<int>() { ItemID.GuideVoodooDoll } },
+			{ "Terraria QueenSlimeBoss", new List<int>() { ItemID.QueenSlimeCrystal } },
+			{ "Terraria TheTwins", new List<int>() { ItemID.MechanicalEye } },
+			{ "Terraria TheDestroyer", new List<int>() { ItemID.MechanicalWorm } },
+			{ "Terraria SkeletronPrime", new List<int>() { ItemID.MechanicalSkull } },
+			// Terraria Plantera: none
+			{ "Terraria Golem", new List<int>() { ItemID.LihzahrdAltar, ItemID.LihzahrdPowerCell } },
+			{ "Terraria HallowBoss", new List<int>() { ItemID.EmpressButterfly } },
+			{ "Terraria DD2Betsy", new List<int>() { ItemID.DD2ElderCrystal, ItemID.DD2ElderCrystalStand } },
+			{ "Terraria DukeFishron", new List<int>() { ItemID.TruffleWorm } },
+			// Terraria CultistBoss : none
+			{ "Terraria MoonLord", new List<int>() { ItemID.CelestialSigil } },
+			#endregion
+			// Mini-bosses tied to events will not display spawn items
+			#region Event Collectibles
+			{ "Terraria TorchGod", new List<int>() { ItemID.Torch } },
+			{ "Terraria BloodMoon", new List<int>() { ItemID.BloodMoonStarter } },
+			{ "Terraria GoblinArmy", new List<int>() { ItemID.GoblinBattleStandard } },
+			{ "Terraria OldOnesArmy", new List<int>() { ItemID.DD2ElderCrystal, ItemID.DD2ElderCrystalStand } },
+			{ "Terraria FrostLegion", new List<int>() { ItemID.SnowGlobe } },
+			{ "Terraria Eclipse", new List<int>() { ItemID.SolarTablet } },
+			{ "Terraria PirateInvasion", new List<int>() { ItemID.PirateMap } },
+			{ "Terraria PumpkinMoon", new List<int>() { ItemID.PumpkinMoonMedallion } },
+			{ "Terraria FrostMoon", new List<int>() { ItemID.NaughtyPresent } },
+			// Terraria MartianMadness: none
+			// Terraria LunarEvent: none
+			#endregion
+		};
+
+		internal readonly Dictionary<string, List<int>> EntryCollections = new Dictionary<string, List<int>>() {
 			#region Boss Collectibles
 			{ "Terraria KingSlime",
-				new List<int>(){
+				new List<int>() {
 					ItemID.KingSlimeMasterTrophy,
 					ItemID.KingSlimePetItem,
 					ItemID.KingSlimeTrophy,
@@ -419,7 +461,7 @@ namespace BossChecklist
 				}
 			},
 			{ "Terraria EyeofCthulhu",
-				new List<int>(){
+				new List<int>() {
 					ItemID.EyeofCthulhuMasterTrophy,
 					ItemID.EyeOfCthulhuPetItem,
 					ItemID.EyeofCthulhuTrophy,
@@ -1043,41 +1085,15 @@ namespace BossChecklist
 			ItemID.MusicBoxOWHallow,
 		};
 
-		// Old version compatibility methods
-		internal void AddBoss(string bossname, float bossValue, Func<bool> bossDowned, string spawnInfo = null, Func<bool> available = null) {
-			SortedEntries.Add(new EntryInfo(EntryType.Boss, "Unknown", bossname, new List<int>(), bossValue, bossDowned, available, new List<int>(), new List<int>(), spawnInfo, null, null));
+		internal void AddEntry(EntryType type, Mod mod, string iName, float val, LocalizedText name, List<int> id, Func<bool> down, LocalizedText info, Dictionary<string, object> extra = null) {
+			EnsureBossIsNotDuplicate(mod?.Name ?? "Unknown", iName);
+			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, name, id, down, info, extra));
+			LogNewBoss(mod?.Name ?? "Unknown", iName);
 		}
 
-		internal void AddMiniBoss(string bossname, float bossValue, Func<bool> bossDowned, string spawnInfo = null, Func<bool> available = null) {
-			SortedEntries.Add(new EntryInfo(EntryType.MiniBoss, "Unknown", bossname, new List<int>(), bossValue, bossDowned, available, new List<int>(), new List<int>(), spawnInfo, null, null));
-		}
-
-		internal void AddEvent(string bossname, float bossValue, Func<bool> bossDowned, string spawnInfo = null, Func<bool> available = null) {
-			SortedEntries.Add(new EntryInfo(EntryType.Event, "Unknown", bossname, new List<int>(), bossValue, bossDowned, available, new List<int>(), new List<int>(), spawnInfo, null, null));
-		}
-
-		// New system
-		internal void AddBoss(Mod source, string name, List<int> id, float val, Func<bool> down, Func<bool> available, List<int> collect, List<int> spawn, string info, Func<NPC, string> despawn = null, Action<SpriteBatch, Rectangle, Color> drawing = null, List<string> headTextures = null) {
-			EnsureBossIsNotDuplicate(source?.Name ?? "Unknown", name);
-			SortedEntries.Add(new EntryInfo(EntryType.Boss, source?.Name ?? "Unknown", name, id, val, down, available, collect, spawn, info, despawn, drawing, headTextures));
-			LogNewBoss(source?.Name ?? "Unknown", Language.GetTextValue(name.StartsWith("?") ? name.Substring(1) : name));
-		}
-
-		internal void AddMiniBoss(Mod source, string name, List<int> id, float val, Func<bool> down, Func<bool> available, List<int> collect, List<int> spawn, string info, Func<NPC, string> despawn = null, Action<SpriteBatch, Rectangle, Color> drawing = null, List<string> headTextures = null) {
-			EnsureBossIsNotDuplicate(source?.Name ?? "Unknown", name);
-			SortedEntries.Add(new EntryInfo(EntryType.MiniBoss, source?.Name ?? "Unknown", name, id, val, down, available, collect, spawn, info, despawn, drawing, headTextures));
-			LogNewBoss(source?.Name ?? "Unknown", Language.GetTextValue(name.StartsWith("?") ? name.Substring(1) : name));
-		}
-
-		internal void AddEvent(Mod source, string name, List<int> id, float val, Func<bool> down, Func<bool> available, List<int> collect, List<int> spawn, string info, Action<SpriteBatch, Rectangle, Color> drawing = null, List<string> headTextures = null) {
-			EnsureBossIsNotDuplicate(source?.Name ?? "Unknown", name);
-			SortedEntries.Add(new EntryInfo(EntryType.Event, source?.Name ?? "Unknown", name, id, val, down, available, collect, spawn, info, null, drawing, headTextures));
-			LogNewBoss(source?.Name ?? "Unknown", Language.GetTextValue(name.StartsWith("?") ? name.Substring(1) : name));
-		}
-
-		internal void EnsureBossIsNotDuplicate(string mod, string bossname) {
-			if (SortedEntries.Any(x=> x.Key == $"{mod} {bossname}"))
-				throw new Exception($"Check your code for duplicate entries or typos, as this entry has already been registered: [{mod} {bossname}]");
+		internal void EnsureBossIsNotDuplicate(string mod, string internalName) {
+			if (SortedEntries.Any(x=> x.Key == $"{mod} {internalName}"))
+				throw new Exception($"Check your code for duplicate entries or typos, as this entry has already been registered: [{mod} {internalName}]");
 		}
 
 		internal void LogNewBoss(string mod, string name) {

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -1097,7 +1097,7 @@ namespace BossChecklist
 
 		internal void AddOrphanData(OrphanType type, Mod mod, Dictionary<string, object> values) {
 			if (values is null) {
-				BossChecklist.instance.Logger.Warn($"{type} mod call from {mod.Name} is structured improperly. Mod developers can refer to link below:\n https://github.com/JavidPack/BossChecklist/wiki/[1.4]-Other-Mod-Calls");
+				BossChecklist.instance.Logger.Warn($"{type} mod call from {mod.Name} is structured improperly. Mod developers can refer to link below:\n https://github.com/JavidPack/BossChecklist/wiki/[1.4.4]-Other-Mod-Calls");
 			}
 			else {
 				ExtraData.Add(new OrphanInfo(type, mod.Name, values));

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -1089,9 +1089,9 @@ namespace BossChecklist
 			ItemID.MusicBoxOWHallow,
 		};
 
-		internal void AddEntry(EntryType type, Mod mod, string iName, float val, LocalizedText name, List<int> id, Func<bool> down, Dictionary<string, object> extra = null) {
+		internal void AddEntry(EntryType type, Mod mod, string iName, float val, List<int> id, Func<bool> down, Dictionary<string, object> extra = null) {
 			EnsureBossIsNotDuplicate(mod?.Name ?? "Unknown", iName);
-			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, name, id, down, extra));
+			SortedEntries.Add(new EntryInfo(type, mod?.Name ?? "Unknown", iName, val, id, down, extra));
 			LogNewBoss(mod?.Name ?? "Unknown", iName);
 		}
 

--- a/Configs.cs
+++ b/Configs.cs
@@ -335,8 +335,6 @@ namespace BossChecklist
 		public bool ShowInactiveBossCheck { get; set; }
 
 		[BackgroundColor(80, 80, 80)]
-		[LabelKey("$Mods.BossChecklist.Configs.DebugConfiguration.DisableAutoLocalization.Label")]
-		[TooltipKey("$Mods.BossChecklist.Configs.DebugConfiguration.DisableAutoLocalization.Tooltip")]
 		public bool DisableAutoLocalization { get; set; }
 
 		[Header("DebugRecordTracker")]

--- a/Configs.cs
+++ b/Configs.cs
@@ -334,6 +334,11 @@ namespace BossChecklist
 		[TooltipKey("$Mods.BossChecklist.Configs.DebugConfiguration.InactiveBossCheck.Tooltip")]
 		public bool ShowInactiveBossCheck { get; set; }
 
+		[BackgroundColor(80, 80, 80)]
+		[LabelKey("$Mods.BossChecklist.Configs.DebugConfiguration.DisableAutoLocalization.Label")]
+		[TooltipKey("$Mods.BossChecklist.Configs.DebugConfiguration.DisableAutoLocalization.Tooltip")]
+		public bool DisableAutoLocalization { get; set; }
+
 		[Header("DebugRecordTracker")]
 
 		[BackgroundColor(255, 250, 250)]

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -381,31 +381,24 @@ namespace BossChecklist
 	internal class OrphanInfo
 	{
 		internal OrphanType type;
-		internal string Key;
 		internal string modSource;
-		internal string bossName;
+		internal Dictionary<string, object> values;
 
-		internal List<int> values;
-		// Use cases for values...
-		/// Adding Spawn Item IDs to a boss
-		/// Adding Collectible item IDs to a boss
-		/// Adding NPC IDs to an event
-
-		internal OrphanInfo(OrphanType type, string bossKey, List<int> values) {
+		internal OrphanInfo(OrphanType type, string modSource, Dictionary<string, object> values) {
 			this.type = type;
-			this.Key = bossKey;
-			this.values = values;
+			this.modSource = modSource;
 
-			List<EntryInfo> bosses = BossChecklist.bossTracker.SortedEntries;
-			int index = bosses.FindIndex(x => x.Key == this.Key);
-			if (index != -1) {
-				modSource = bosses[index].SourceDisplayName;
-				bossName = bosses[index].DisplayName;
+			// Sort through the data submissions to remove any invalid data
+			foreach (string Key in values.Keys) {
+				if (!Key.Contains(' ')) {
+					values.Remove(Key); // remove submissions with invalid keys (no space between modSource and internalName)
+					BossChecklist.instance.Logger.Warn($"A {type} call from {modSource} contains an invalid key ({Key})");
+				}
+				else if (!ModLoader.TryGetMod(Key.Substring(0, Key.IndexOf(" ")), out Mod mod)) {
+					values.Remove(Key); // remove submissions that use an entry key from an unloaded mod
+				}
 			}
-			else {
-				modSource = "Unknown";
-				bossName = "Unknown";
-			}
+			this.values = values;
 		}
 	}
 }

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -26,7 +26,7 @@ namespace BossChecklist
 		internal Func<bool> downed;
 		internal Func<bool> available;
 		internal bool hidden;
-		internal Func<NPC, string> customDespawnMessages;
+		internal Func<NPC, LocalizedText> customDespawnMessages;
 
 		internal List<string> relatedEntries;
 
@@ -198,7 +198,7 @@ namespace BossChecklist
 			this.spawnItem = extraData?.ContainsKey("spawnItems") == true ? InterpretObjectAsListOfInt(extraData["spawnItems"]) : new List<int>();
 			this.collection = extraData?.ContainsKey("collectibles") == true ? InterpretObjectAsListOfInt(extraData["collectibles"]) : new List<int>();
 			this.customDrawing = extraData?.ContainsKey("customPortrait") == true ? extraData["customPortrait"] as Action<SpriteBatch, Rectangle, Color> : null;
-			this.customDespawnMessages = entryType != EntryType.Event && extraData?.ContainsKey("despawnMessage") == true ? extraData["despawnMessage"] as Func<NPC, string> : null;
+			this.customDespawnMessages = entryType != EntryType.Event && extraData?.ContainsKey("despawnMessage") == true ? extraData["despawnMessage"] as Func<NPC, LocalizedText> : null;
 
 			headIconTextures = new List<Asset<Texture2D>>();
 			if (extraData?.ContainsKey("overrideHeadTextures") == true) {
@@ -262,7 +262,7 @@ namespace BossChecklist
 			string nameKey = key.Substring(key.LastIndexOf(".") + 1);
 			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
-			Func<NPC, string> customMessages = null;
+			Func<NPC, LocalizedText> customMessages = null;
 			if (type == EntryType.Boss) {
 				List<int> DayDespawners = new List<int>() {
 					NPCID.EyeofCthulhu,
@@ -274,7 +274,7 @@ namespace BossChecklist
 				bool DayCheck(int type) => Main.dayTime && DayDespawners.Contains(type);
 				bool AllPlayersAreDead() => Main.player.All(plr => !plr.active || plr.dead);
 				string customKey = $"{NPCAssist.LangChat}.Loss.{nameKey}";
-				customMessages = npc => AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic";
+				customMessages = npc => Language.GetText(AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic");
 			}
 
 			return new EntryInfo(
@@ -298,7 +298,7 @@ namespace BossChecklist
 			string nameKey = key.Substring(key.LastIndexOf(".") + 1).Replace(" ", "").Replace("'", "");
 			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
-			Func<NPC, string> customMessages = null;
+			Func<NPC, LocalizedText> customMessages = null;
 			if (type == EntryType.Boss) {
 				List<int> DayDespawners = new List<int>() {
 					NPCID.EyeofCthulhu,
@@ -310,7 +310,7 @@ namespace BossChecklist
 				bool DayCheck(int type) => Main.dayTime && DayDespawners.Contains(type);
 				bool AllPlayersAreDead() => Main.player.All(plr => !plr.active || plr.dead);
 				string customKey = $"{NPCAssist.LangChat}.Loss.{nameKey}";
-				customMessages = npc => AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic";
+				customMessages = npc => Language.GetText(AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic");
 			}
 
 			return new EntryInfo(

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -13,6 +13,12 @@ using Microsoft.Xna.Framework;
 
 namespace BossChecklist
 {
+	internal enum EntryType {
+		Boss,
+		MiniBoss,
+		Event
+	}
+
 	internal class EntryInfo // Inheritance for Event instead?
 	{
 		// This localization-ignoring string is used for cross mod queries and networking. Each key is completely unique.
@@ -363,6 +369,13 @@ namespace BossChecklist
 		}
 
 		public override string ToString() => $"{progression} {Key}";
+	}
+
+	internal enum OrphanType {
+		Loot,
+		Collection,
+		SpawnItem,
+		EventNPC
 	}
 
 	internal class OrphanInfo

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -353,8 +353,8 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				npcIDs: new List<int>() { npcID },
 				downed: downed,
+				npcIDs: new List<int>() { npcID },
 				extraData: new Dictionary<string, object>() {
 					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
@@ -395,8 +395,8 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				npcIDs: ids,
 				downed: downed,
+				npcIDs: ids,
 				extraData: new Dictionary<string, object>() {
 					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
@@ -414,8 +414,8 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				npcIDs: BossChecklist.bossTracker.EventNPCs.GetValueOrDefault($"Terraria {nameKey}"),
 				downed: downed,
+				npcIDs: BossChecklist.bossTracker.EventNPCs.GetValueOrDefault($"Terraria {nameKey}"),
 				extraData: new Dictionary<string, object>() {
 					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -192,7 +192,7 @@ namespace BossChecklist
 			return true; // if it passes all the checks, it should be shown
 		}
 
-		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, LocalizedText name, List<int> npcIDs, Func<bool> downed, Dictionary<string, object> extraData = null) {
+		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, List<int> npcIDs, Func<bool> downed, Dictionary<string, object> extraData = null) {
 			// Add the mod source to the opted mods list of the credits page if its not already and add the entry type
 			if (modSource != "Terraria" && modSource != "Unknown") {
 				BossUISystem.Instance.RegisteredMods.TryAdd(modSource, new int[3]);
@@ -209,6 +209,7 @@ namespace BossChecklist
 			this.downed = downed;
 
 			// Localization checks
+			LocalizedText name = extraData?.ContainsKey("displayName") == true ? extraData["displayName"] as LocalizedText : null;
 			LocalizedText spawnInfo = extraData?.ContainsKey("spawnInfo") == true ? extraData["spawnInfo"] as LocalizedText : null;
 
 			if (name == null || spawnInfo == null) {
@@ -353,10 +354,10 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				name: Language.GetText(key),
 				npcIDs: new List<int>() { npcID },
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
+					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
@@ -395,10 +396,10 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				name: Language.GetText(key),
 				npcIDs: ids,
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
+					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
@@ -414,10 +415,10 @@ namespace BossChecklist
 				modSource: "Terraria",
 				internalName: nameKey,
 				progression: val,
-				name: Language.GetText(key),
 				npcIDs: BossChecklist.bossTracker.EventNPCs.GetValueOrDefault($"Terraria {nameKey}"),
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
+					{ "displayName", Language.GetText(key) },
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -252,7 +252,17 @@ namespace BossChecklist
 			this.spawnItem = extraData?.ContainsKey("spawnItems") == true ? InterpretObjectAsListOfInt(extraData["spawnItems"]) : new List<int>();
 			this.collection = extraData?.ContainsKey("collectibles") == true ? InterpretObjectAsListOfInt(extraData["collectibles"]) : new List<int>();
 			this.customDrawing = extraData?.ContainsKey("customPortrait") == true ? extraData["customPortrait"] as Action<SpriteBatch, Rectangle, Color> : null;
-			this.customDespawnMessages = entryType != EntryType.Event && extraData?.ContainsKey("despawnMessage") == true ? extraData["despawnMessage"] as Func<NPC, LocalizedText> : null;
+			if (extraData?.ContainsKey("despawnMessage") == true) {
+				if (extraData["despawnMessage"] is Func<NPC, LocalizedText> multiMessage) {
+					this.customDespawnMessages = multiMessage;
+				}
+				else if (extraData["despawnMessage"] is LocalizedText singleMessage) {
+					this.customDespawnMessages = (NPC npc) => singleMessage.WithFormatArgs(npc.FullName);
+				}
+				else {
+					this.customDespawnMessages = null;
+				}
+			}
 
 			headIconTextures = new List<Asset<Texture2D>>();
 			if (extraData?.ContainsKey("overrideHeadTextures") == true) {

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -325,7 +325,6 @@ namespace BossChecklist
 		}
 		internal static EntryInfo MakeVanillaBoss(EntryType type, float val, string key, int npcID, Func<bool> downed) {
 			string nameKey = key.Substring(key.LastIndexOf(".") + 1);
-			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
 			Func<NPC, LocalizedText> customMessages = null;
 			if (type == EntryType.Boss) { // BossChecklist only has despawn messages for vanilla Bosses
@@ -358,7 +357,7 @@ namespace BossChecklist
 				npcIDs: new List<int>() { npcID },
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
-					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
+					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },
@@ -368,7 +367,6 @@ namespace BossChecklist
 
 		internal static EntryInfo MakeVanillaBoss(EntryType type, float val, string key, List<int> ids, Func<bool> downed) {
 			string nameKey = key.Substring(key.LastIndexOf(".") + 1).Replace(" ", "").Replace("'", "");
-			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
 			Func<NPC, LocalizedText> customMessages = null;
 			if (type == EntryType.Boss) { // BossChecklist only has despawn messages for vanilla Bosses
@@ -401,7 +399,7 @@ namespace BossChecklist
 				npcIDs: ids,
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
-					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
+					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -179,7 +179,7 @@ namespace BossChecklist
 			this.progression = progression;
 
 			this.name = name;
-			this.npcIDs = npcIDs;
+			this.npcIDs = npcIDs ?? new List<int>();
 			this.downed = downed;
 			this.spawnInfo = spawnInfo;
 

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -200,6 +200,9 @@ namespace BossChecklist
 					int primaryNPCID = npcIDs?.Count > 0 ? npcIDs[0] : 0;
 					if (ModContent.GetModNPC(primaryNPCID) is ModNPC modNPC) {
 						prefix = modNPC.GetLocalizationKey("BossChecklistIntegration");
+						// For single NPC bosses, assume EntryName is DisplayName rather than registering a localization key.
+						if (/*internalName == modNPC.Name &&*/ npcIDs.Count == 1 && !Language.Exists($"{prefix}.EntryName"))
+							name ??= modNPC.DisplayName;
 						name ??= Language.GetOrRegister($"{prefix}.EntryName", () => Regex.Replace(internalName, "([A-Z])", " $1").Trim());
 						spawnInfo ??= Language.GetOrRegister($"{prefix}.SpawnInfo", () => "Conditions unknown"); // Register English/default, not localized.
 					}

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -192,7 +192,7 @@ namespace BossChecklist
 			return true; // if it passes all the checks, it should be shown
 		}
 
-		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, List<int> npcIDs, Func<bool> downed, Dictionary<string, object> extraData = null) {
+		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, Func<bool> downed, List<int> npcIDs, Dictionary<string, object> extraData = null) {
 			// Add the mod source to the opted mods list of the credits page if its not already and add the entry type
 			if (modSource != "Terraria" && modSource != "Unknown") {
 				BossUISystem.Instance.RegisteredMods.TryAdd(modSource, new int[3]);
@@ -204,9 +204,8 @@ namespace BossChecklist
 			this.type = entryType;
 			this.modSource = modSource;
 			this.progression = progression;
-
-			this.npcIDs = npcIDs ?? new List<int>();
 			this.downed = downed;
+			this.npcIDs = npcIDs ?? new List<int>();
 
 			// Localization checks
 			LocalizedText name = extraData?.ContainsKey("displayName") == true ? extraData["displayName"] as LocalizedText : null;

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -195,7 +195,7 @@ namespace BossChecklist
 			List<string> InterpretObjectAsListOfStrings(object data) => data is List<string> ? data as List<string> : (data is string ? new List<string>() { data as string } : null);
 
 			this.available = extraData?.ContainsKey("availability") == true ? extraData["availability"] as Func<bool> : () => true;
-			this.spawnItem = extraData?.ContainsKey("spawnItem") == true ? InterpretObjectAsListOfInt(extraData["spawnItem"]) : new List<int>();
+			this.spawnItem = extraData?.ContainsKey("spawnItems") == true ? InterpretObjectAsListOfInt(extraData["spawnItems"]) : new List<int>();
 			this.collection = extraData?.ContainsKey("collectibles") == true ? InterpretObjectAsListOfInt(extraData["collectibles"]) : new List<int>();
 			this.customDrawing = extraData?.ContainsKey("customPortrait") == true ? extraData["customPortrait"] as Action<SpriteBatch, Rectangle, Color> : null;
 			this.customDespawnMessages = entryType != EntryType.Event && extraData?.ContainsKey("despawnMessage") == true ? extraData["despawnMessage"] as Func<NPC, string> : null;

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -184,10 +184,13 @@ namespace BossChecklist
 			this.modSource = modSource;
 			this.progression = progression;
 
-			this.name = name;
 			this.npcIDs = npcIDs ?? new List<int>();
 			this.downed = downed;
-			this.spawnInfo = spawnInfo;
+
+			// Localization checks
+			string prefix = type == EntryType.Event ? $"Mods.{modSource}.BossChecklistIntegration.{internalName}" : $"Mods.{modSource}.NPCs.{ModContent.GetModNPC(npcIDs[0]).Name}.BossChecklistIntegration";
+			this.name = name ?? Language.GetText(prefix + ".EntryName");
+			this.spawnInfo = spawnInfo ?? Language.GetText(prefix + ".SpawnInfo");
 
 			// self-initializing data
 			this.hidden = false; // defaults to false, hidden status can be toggled per world

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -144,6 +144,26 @@ namespace BossChecklist
 		}
 
 		/// <summary>
+		/// Determines what despawn message should be used based on client configuration and submitted entry data.
+		/// </summary>
+		/// <returns>A LocalizedText of the despawn message of the passed npc. Returns null if no message can be found.</returns>
+		internal LocalizedText GetDespawnMessage(NPC npc) {
+			if (npc.life <= 0)
+				return null; // If the boss was killed, don't display a despawn message
+
+			// When unique despawn messages are enabled, pass the NPC for the custom message function provided by the entry
+			if (BossChecklist.ClientConfig.DespawnMessageType == "Unique" && customDespawnMessages(npc) is LocalizedText message)
+				return message; // this will only return a unique message if the custom message function properly assigns one
+
+			// If the Unique message was empty/null or the player is using Generic despawn messages, try to find an appropriate despawn message to send
+			// Return a generic despawn message if any player is left alive or return a boss victory despawn message if all player's were killed
+			if (BossChecklist.ClientConfig.DespawnMessageType != "Disabled")
+				return Language.GetText(Main.player.Any(plr => plr.active && !plr.dead) ? $"{NPCAssist.LangChat}.Despawn.Generic" : $"{NPCAssist.LangChat}.Loss.Generic");
+
+			return null; // The despawn message feature was disabled. Return an empty message.
+		}
+
+		/// <summary>
 		/// Determines whether or not the entry should be visible on the Table of Contents, 
 		/// based on configurations and filter status.
 		/// </summary>

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -263,7 +263,7 @@ namespace BossChecklist
 			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
 			Func<NPC, LocalizedText> customMessages = null;
-			if (type == EntryType.Boss) {
+			if (type == EntryType.Boss) { // BossChecklist only has despawn messages for vanilla Bosses
 				List<int> DayDespawners = new List<int>() {
 					NPCID.EyeofCthulhu,
 					NPCID.Retinazer,
@@ -271,10 +271,17 @@ namespace BossChecklist
 					NPCID.TheDestroyer,
 				};
 
-				bool DayCheck(int type) => Main.dayTime && DayDespawners.Contains(type);
-				bool AllPlayersAreDead() => Main.player.All(plr => !plr.active || plr.dead);
-				string customKey = $"{NPCAssist.LangChat}.Loss.{nameKey}";
-				customMessages = npc => Language.GetText(AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic");
+				customMessages = delegate (NPC npc) {
+					if (Main.player.All(plr => !plr.active || plr.dead)) {
+						return Language.GetText($"{NPCAssist.LangChat}.Loss.{nameKey}"); // Despawn message when all players are dead
+					}
+					else if (Main.dayTime && DayDespawners.Contains(npc.type)) {
+						return Language.GetText($"{NPCAssist.LangChat}.Despawn.Day"); // Despawn message when it turns to day
+					}
+
+					// unique despawn messages should default to the generic message when no conditions are met
+					return Language.GetText($"{NPCAssist.LangChat}.Despawn.Generic");
+				};
 			}
 
 			return new EntryInfo(

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -192,7 +192,7 @@ namespace BossChecklist
 			return true; // if it passes all the checks, it should be shown
 		}
 
-		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, LocalizedText name, List<int> npcIDs, Func<bool> downed, LocalizedText spawnInfo, Dictionary<string, object> extraData = null) {
+		internal EntryInfo(EntryType entryType, string modSource, string internalName, float progression, LocalizedText name, List<int> npcIDs, Func<bool> downed, Dictionary<string, object> extraData = null) {
 			// Add the mod source to the opted mods list of the credits page if its not already and add the entry type
 			if (modSource != "Terraria" && modSource != "Unknown") {
 				BossUISystem.Instance.RegisteredMods.TryAdd(modSource, new int[3]);
@@ -209,9 +209,10 @@ namespace BossChecklist
 			this.downed = downed;
 
 			// Localization checks
-			if(name == null || spawnInfo == null) {
+			LocalizedText spawnInfo = extraData?.ContainsKey("spawnInfo") == true ? extraData["spawnInfo"] as LocalizedText : null;
+
+			if (name == null || spawnInfo == null) {
 				// Modded. Ensure that all nulls passed in autoregister a localization key.
-				string prefix;
 				if (type == EntryType.Event) {
 					name ??= Language.GetOrRegister($"Mods.{modSource}.BossChecklistIntegration.{internalName}.EntryName", () => Regex.Replace(internalName, "([A-Z])", " $1").Trim()); // Add spaces before each capital letter.
 					spawnInfo ??= Language.GetOrRegister($"Mods.{modSource}.BossChecklistIntegration.{internalName}.SpawnInfo", () => "Spawn conditions unknown");
@@ -219,12 +220,12 @@ namespace BossChecklist
 				else {
 					int primaryNPCID = npcIDs?.Count > 0 ? npcIDs[0] : 0;
 					if (ModContent.GetModNPC(primaryNPCID) is ModNPC modNPC) {
-						prefix = modNPC.GetLocalizationKey("BossChecklistIntegration");
+						string prefix = modNPC.GetLocalizationKey("BossChecklistIntegration");
 						// For single NPC bosses, assume EntryName is DisplayName rather than registering a localization key.
 						if (/*internalName == modNPC.Name &&*/ npcIDs.Count == 1 && !Language.Exists($"{prefix}.EntryName"))
 							name ??= modNPC.DisplayName;
 						name ??= Language.GetOrRegister($"{prefix}.EntryName", () => Regex.Replace(internalName, "([A-Z])", " $1").Trim());
-						spawnInfo ??= Language.GetOrRegister($"{prefix}.SpawnInfo", () => "Conditions unknown"); // Register English/default, not localized.
+						spawnInfo ??= Language.GetOrRegister($"{prefix}.SpawnInfo", () => "Spawn conditions unknown"); // Register English/default, not localized.
 					}
 					else {
 						// Mod registered boss for vanilla npc or no npcids?
@@ -356,8 +357,8 @@ namespace BossChecklist
 				name: Language.GetText(key),
 				npcIDs: new List<int>() { npcID },
 				downed: downed,
-				Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}"),
 				extraData: new Dictionary<string, object>() {
+					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
 					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },
@@ -399,8 +400,8 @@ namespace BossChecklist
 				name: Language.GetText(key),
 				npcIDs: ids,
 				downed: downed,
-				spawnInfo: Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}"),
 				extraData: new Dictionary<string, object>() {
+					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
 					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },
@@ -418,8 +419,8 @@ namespace BossChecklist
 				name: Language.GetText(key),
 				npcIDs: BossChecklist.bossTracker.EventNPCs.GetValueOrDefault($"Terraria {nameKey}"),
 				downed: downed,
-				spawnInfo: Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}"),
 				extraData: new Dictionary<string, object>() {
+					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
 					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 				}

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -258,7 +258,7 @@ namespace BossChecklist
 					this.customDespawnMessages = multiMessage;
 				}
 				else if (extraData["despawnMessage"] is LocalizedText singleMessage) {
-					this.customDespawnMessages = (NPC npc) => singleMessage.WithFormatArgs(npc.FullName);
+					this.customDespawnMessages = (NPC npc) => singleMessage;
 				}
 				else {
 					this.customDespawnMessages = null;

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -100,9 +100,9 @@ namespace BossChecklist
 			return dict;
 		}
 
-		internal string DisplayName => Language.GetTextValue(name.Key);
+		internal string DisplayName => name.Value;
 
-		internal string DisplaySpawnInfo => Language.GetTextValue(spawnInfo.Key);
+		internal string DisplaySpawnInfo => spawnInfo.Value;
 		
 		internal string SourceDisplayName => modSource == "Terraria" || modSource == "Unknown" ? modSource : SourceDisplayNameWithoutChatTags(ModLoader.GetMod(modSource).DisplayName);
 

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -91,7 +91,7 @@ namespace BossChecklist
 				{ "isEvent", type.Equals(EntryType.Event) },
 
 				{ "npcIDs", new List<int>(npcIDs) },
-				{ "spawnItem", new List<int>(spawnItem) },
+				{ "spawnItems", new List<int>(spawnItem) },
 				{ "treasureBag", treasureBag },
 				{ "loot", new List<DropRateInfo>(loot) },
 				{ "collection", new List<int>(collection) }
@@ -359,7 +359,7 @@ namespace BossChecklist
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
-					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
+					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },
 				}
@@ -402,7 +402,7 @@ namespace BossChecklist
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}{tremor}") },
-					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
+					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "despawnMessage", customMessages },
 				}
@@ -421,7 +421,7 @@ namespace BossChecklist
 				downed: downed,
 				extraData: new Dictionary<string, object>() {
 					{ "spawnInfo", Language.GetText($"Mods.BossChecklist.BossSpawnInfo.{nameKey}") },
-					{ "spawnItem", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
+					{ "spawnItems", BossChecklist.bossTracker.EntrySpawnItems.GetValueOrDefault($"Terraria {nameKey}") },
 					{ "collectibles", BossChecklist.bossTracker.EntryCollections.GetValueOrDefault($"Terraria {nameKey}") },
 				}
 			);

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -306,7 +306,7 @@ namespace BossChecklist
 			string tremor = nameKey == "MoodLord" && BossChecklist.tremorLoaded ? "_Tremor" : "";
 
 			Func<NPC, LocalizedText> customMessages = null;
-			if (type == EntryType.Boss) {
+			if (type == EntryType.Boss) { // BossChecklist only has despawn messages for vanilla Bosses
 				List<int> DayDespawners = new List<int>() {
 					NPCID.EyeofCthulhu,
 					NPCID.Retinazer,
@@ -314,10 +314,17 @@ namespace BossChecklist
 					NPCID.TheDestroyer,
 				};
 
-				bool DayCheck(int type) => Main.dayTime && DayDespawners.Contains(type);
-				bool AllPlayersAreDead() => Main.player.All(plr => !plr.active || plr.dead);
-				string customKey = $"{NPCAssist.LangChat}.Loss.{nameKey}";
-				customMessages = npc => Language.GetText(AllPlayersAreDead() ? customKey : DayCheck(npc.type) ? $"{NPCAssist.LangChat}.Despawn.Day" : $"{NPCAssist.LangChat}.Despawn.Generic");
+				customMessages = delegate (NPC npc) {
+					if (Main.player.All(plr => !plr.active || plr.dead)) {
+						return Language.GetText($"{NPCAssist.LangChat}.Loss.{nameKey}"); // Despawn message when all players are dead
+					}
+					else if (Main.dayTime && DayDespawners.Contains(npc.type)) {
+						return Language.GetText($"{NPCAssist.LangChat}.Despawn.Day"); // Despawn message when it turns to day
+					}
+
+					// unique despawn messages should default to the generic message when no conditions are met
+					return Language.GetText($"{NPCAssist.LangChat}.Despawn.Generic");
+				};
 			}
 
 			return new EntryInfo(

--- a/IDs.cs
+++ b/IDs.cs
@@ -2,21 +2,6 @@
 
 namespace BossChecklist
 {
-	internal enum EntryType
-	{
-		Boss,
-		MiniBoss,
-		Event
-	}
-
-	internal enum OrphanType
-	{
-		Loot,
-		Collection,
-		SpawnItem,
-		EventNPC
-	}
-
 	internal enum CollectionType
 	{
 		Generic,

--- a/Localization/de-DE.hjson
+++ b/Localization/de-DE.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			// KingSlime: Use [i:560], randomly in outer 3rds of map, or kill 150 slimes during slime rain.
 			// EyeofCthulhu: Use [i:43] at night, or 1/3 chance nightly if over 200 HP.
 			// EaterofWorldsHead: Use [i:70] or break 3 Shadow Orbs in a corruption chasm.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -503,6 +503,16 @@ Mods: {
 						'''
 				}
 
+				DisableAutoLocalization: {
+					Label: Disable Auto Localization
+					Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
+						'''
+				}
+
 				DisableNewRecords: {
 					Label: Disable updating personal records
 					Tooltip:

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			Unknown: Spawn conditions unknown
 			KingSlime: Use [i:560], randomly in outer 3rds of map, or kill 150 slimes during slime rain.
 			EyeofCthulhu: Use [i:43] at night, or 1/3 chance nightly if over 200 HP.
 			EaterofWorldsHead: Use [i:70] or break 3 Shadow Orbs in a corruption chasm.

--- a/Localization/es-ES.hjson
+++ b/Localization/es-ES.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			KingSlime: Usando [i:560], al azar al no estar en el centro del mapa o matando 150 slimes durante la Lluvia de slimes.
 			EyeofCthulhu: Usando [i:43] de noche, o con 1/3 de probabilidades de aparecer por la noche teniendo más de 200 PS.
 			EaterofWorldsHead: Usando [i:70] o rompiendo 3 orbes sombríos en un abismo corrupto.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/fr-FR.hjson
+++ b/Localization/fr-FR.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			// KingSlime: Use [i:560], randomly in outer 3rds of map, or kill 150 slimes during slime rain.
 			// EyeofCthulhu: Use [i:43] at night, or 1/3 chance nightly if over 200 HP.
 			// EaterofWorldsHead: Use [i:70] or break 3 Shadow Orbs in a corruption chasm.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/it-IT.hjson
+++ b/Localization/it-IT.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			// KingSlime: Use [i:560], randomly in outer 3rds of map, or kill 150 slimes during slime rain.
 			// EyeofCthulhu: Use [i:43] at night, or 1/3 chance nightly if over 200 HP.
 			// EaterofWorldsHead: Use [i:70] or break 3 Shadow Orbs in a corruption chasm.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/pl-PL.hjson
+++ b/Localization/pl-PL.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			// KingSlime: Use [i:560], randomly in outer 3rds of map, or kill 150 slimes during slime rain.
 			// EyeofCthulhu: Use [i:43] at night, or 1/3 chance nightly if over 200 HP.
 			// EaterofWorldsHead: Use [i:70] or break 3 Shadow Orbs in a corruption chasm.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/pt-BR.hjson
+++ b/Localization/pt-BR.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			KingSlime: Use [i:560], aleatoriamente nos terços externos do mapa, ou mate 150 geleias durante a chuva de geleias.
 			EyeofCthulhu: Use [i:43] à noite, ou 1/3 de chance à noite se tiver mais de 200 PV.
 			EaterofWorldsHead: Use [i:70] ou quebre 3 Esferas das Sombras em um abismo da corrupção.
@@ -500,6 +501,16 @@ Mods: {
 						While enabled, a message will be displayed in chat when records have begun calculating, if record tracking is enabled.
 						This should also display a message in chat when a despawn message appears, if despawn messages are enabled.
 						These messages should appear when a boss has been defeated or a boss has despawned, respectively.
+						''' */
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
 						''' */
 				}
 

--- a/Localization/ru-RU.hjson
+++ b/Localization/ru-RU.hjson
@@ -211,6 +211,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			KingSlime: Используйте [i:560] в любой точке карты мира или убейте 150 слизней во время слизнепада.
 			EyeofCthulhu: Используйте [i:43] ночью или дождитесь, пока босс придёт естественным образом ночью с шансом 33%, когда его здоровье больше 200.
 			EaterofWorldsHead: Используйте [i:70] или сломайте 3 теневых сферы в пучинах искажения.
@@ -505,6 +506,16 @@ Mods: {
 						Это также должно отображать сообщение в чате, когда появляется сообщение об исчезновении, если включено «Сообщение об исчезновении босса».
 						Эти сообщения должны появляться при победе над боссом или при его исчезновении, соответственно.
 						'''
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
+						''' */
 				}
 
 				DisableNewRecords: {

--- a/Localization/zh-Hans.hjson
+++ b/Localization/zh-Hans.hjson
@@ -207,6 +207,7 @@ Mods: {
 		}
 
 		BossSpawnInfo: {
+			// Unknown: Spawn conditions unknown
 			KingSlime: 使用 [i:560], 或在地图外侧的两个 1/6 （最左边或最右边）范围内随机生成, 或者在史莱姆雨期间杀死 150 个史莱姆.
 			EyeofCthulhu: 在夜晚使用 [i:43], 当至少一名玩家最大生命值大于等于 200, 防御值大于等于 10 且未曾被击败时在每个夜晚有 1/3 的几率生成.
 			EaterofWorldsHead: 在腐化之地使用 [i:70] 或在腐化之地的裂缝中破坏 3 个暗影珠.
@@ -501,6 +502,16 @@ Mods: {
 						如果启用了Boss消失信息，则当显Boss消失信息时，这也应该在聊框天中显示一条消息.
 						这些信息应该分别在Boss被击败或Boss消失时出现.
 						'''
+				}
+
+				DisableAutoLocalization: {
+					// Label: Disable Auto Localization
+					/* Tooltip:
+						'''
+						BossChecklist will detect old calls and create localizations for LocalizedText submissions needed for the new calls.
+						The new calls do not require these localizations but will default to them if null is passed.
+						Set to true to prevent new localizations from being created by BossChecklist.
+						''' */
 				}
 
 				DisableNewRecords: {

--- a/NPCAssist.cs
+++ b/NPCAssist.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using Terraria;
 using Terraria.Chat;
@@ -136,29 +135,6 @@ namespace BossChecklist
 				return true; // If excluding the passed NPC from the active check, this should return true
 
 			return !npc.active; // otherwise, return the NPC's active status
-		}
-
-		/// <summary>
-		/// Determines what despawn message should be used based on client configuration and submitted entry info.
-		/// </summary>
-		/// <returns>A LocalizedText of the despawn message of the passed npc. Returns null if no message can be found.</returns>
-		public static LocalizedText GetDespawnMessage(NPC npc, int index) {
-			if (npc.life <= 0)
-				return null; // If the boss was killed, don't display a despawn message
-
-			// When unique despawn messages are enabled, pass the NPC for the custom message function provided by the entry
-			if (BossChecklist.ClientConfig.DespawnMessageType == "Unique") {
-				LocalizedText customMessage = BossChecklist.bossTracker.SortedEntries[index].customDespawnMessages(npc);
-				if (customMessage != null)
-					return customMessage; // this will only return a unique message if the custom message function properly assigns one
-			}
-
-			// If the Unique message was empty/null or the player is using Generic despawn messages, try to find an appropriate despawn message to send
-			// Return a generic despawn message if any player is left alive or return a boss victory despawn message if all player's were killed
-			if (BossChecklist.ClientConfig.DespawnMessageType != "Disabled")
-				return Language.GetText(Main.player.Any(plr => plr.active && !plr.dead) ? $"{LangChat}.Despawn.Generic" : $"{LangChat}.Loss.Generic");
-
-			return null; // The despawn message feature was disabled. Return an empty message.
 		}
 
 		/// <summary>

--- a/NPCAssist.cs
+++ b/NPCAssist.cs
@@ -141,26 +141,24 @@ namespace BossChecklist
 		/// <summary>
 		/// Determines what despawn message should be used based on client configuration and submitted entry info.
 		/// </summary>
-		/// <returns>A string or key of the despawn message of the passed npc. Returns null if no message can be found.</returns>
-		public static string GetDespawnMessage(NPC npc, int index) {
+		/// <returns>A LocalizedText of the despawn message of the passed npc. Returns null if no message can be found.</returns>
+		public static LocalizedText GetDespawnMessage(NPC npc, int index) {
 			if (npc.life <= 0)
 				return null; // If the boss was killed, don't display a despawn message
 
-			string messageType = BossChecklist.ClientConfig.DespawnMessageType;
-			if (messageType == "Unique") {
-				// When unique despawn messages are enabled, pass the NPC for the custom message function provided by the entry
-				string customMessage = BossChecklist.bossTracker.SortedEntries[index].customDespawnMessages(npc);
-				if (!string.IsNullOrEmpty(customMessage))
+			// When unique despawn messages are enabled, pass the NPC for the custom message function provided by the entry
+			if (BossChecklist.ClientConfig.DespawnMessageType == "Unique") {
+				LocalizedText customMessage = BossChecklist.bossTracker.SortedEntries[index].customDespawnMessages(npc);
+				if (customMessage != null)
 					return customMessage; // this will only return a unique message if the custom message function properly assigns one
 			}
 
-			if (messageType != "Disabled") {
-				// If the Unique message was empty/null or the player is using Generic despawn messages, try to find an appropriate despawn message to send
-				// Return a generic despawn message if any player is left alive or return a boss victory despawn message if all player's were killed
-				return Main.player.Any(plr => plr.active && !plr.dead) ? $"{LangChat}.Despawn.Generic" : $"{LangChat}.Loss.Generic";
-			}
-			// The despawn message feature was disabled. Return an empty message.
-			return null;
+			// If the Unique message was empty/null or the player is using Generic despawn messages, try to find an appropriate despawn message to send
+			// Return a generic despawn message if any player is left alive or return a boss victory despawn message if all player's were killed
+			if (BossChecklist.ClientConfig.DespawnMessageType != "Disabled")
+				return Language.GetText(Main.player.Any(plr => plr.active && !plr.dead) ? $"{LangChat}.Despawn.Generic" : $"{LangChat}.Loss.Generic");
+
+			return null; // The despawn message feature was disabled. Return an empty message.
 		}
 
 		/// <summary>

--- a/WorldAssist.cs
+++ b/WorldAssist.cs
@@ -297,10 +297,10 @@ namespace BossChecklist
 						Tracker_ActiveEntry[recordIndex] = false; // No longer an active boss (only other time this is set to false is NPC.OnKill)
 						if (entry.GetDespawnMessage(npc) is LocalizedText message) {
 							if (Main.netMode == NetmodeID.SinglePlayer) {
-								Main.NewText(Language.GetTextValue(message.Key, npc.FullName), Colors.RarityPurple);
+								Main.NewText(message.Format(npc.FullName), Colors.RarityPurple);
 							}
 							else {
-								ChatHelper.BroadcastChatMessage(NetworkText.FromKey(message.Key, npc.FullName), Colors.RarityPurple);
+								ChatHelper.BroadcastChatMessage(NetworkText.FromLiteral(message.Format(npc.FullName)), Colors.RarityPurple);
 							}
 						}
 					}

--- a/WorldAssist.cs
+++ b/WorldAssist.cs
@@ -295,13 +295,13 @@ namespace BossChecklist
 					// ...check if the npc is actually still active or not and display a despawn message if they are no longer active (but not killed!)
 					if (NPCAssist.FullyInactive(npc, entry.GetIndex)) {
 						Tracker_ActiveEntry[recordIndex] = false; // No longer an active boss (only other time this is set to false is NPC.OnKill)
-						string message = NPCAssist.GetDespawnMessage(npc, entry.GetIndex);
-						if (!string.IsNullOrEmpty(message)) {
+						LocalizedText message = NPCAssist.GetDespawnMessage(npc, entry.GetIndex);
+						if (message != null) {
 							if (Main.netMode == NetmodeID.SinglePlayer) {
-								Main.NewText(Language.GetTextValue(message, npc.FullName), Colors.RarityPurple);
+								Main.NewText(Language.GetTextValue(message.Key, npc.FullName), Colors.RarityPurple);
 							}
 							else {
-								ChatHelper.BroadcastChatMessage(NetworkText.FromKey(message, npc.FullName), Colors.RarityPurple);
+								ChatHelper.BroadcastChatMessage(NetworkText.FromKey(message.Key, npc.FullName), Colors.RarityPurple);
 							}
 						}
 					}

--- a/WorldAssist.cs
+++ b/WorldAssist.cs
@@ -295,8 +295,7 @@ namespace BossChecklist
 					// ...check if the npc is actually still active or not and display a despawn message if they are no longer active (but not killed!)
 					if (NPCAssist.FullyInactive(npc, entry.GetIndex)) {
 						Tracker_ActiveEntry[recordIndex] = false; // No longer an active boss (only other time this is set to false is NPC.OnKill)
-						LocalizedText message = NPCAssist.GetDespawnMessage(npc, entry.GetIndex);
-						if (message != null) {
+						if (entry.GetDespawnMessage(npc) is LocalizedText message) {
 							if (Main.netMode == NetmodeID.SinglePlayer) {
 								Main.NewText(Language.GetTextValue(message.Key, npc.FullName), Colors.RarityPurple);
 							}


### PR DESCRIPTION
## New call arguments for `LogBoss` (previously `AddBoss`)
AddBoss has been changed to LogBoss. The AddBoss calls and its alternatives have been made obsolete. Changing the call message will ensure that all modders know they need to update their mod calls. If a mod does not update their mod calls, a message will be logged, listing all entries that were attempted to be submitted and informing the developers of the new changes with a github wiki link.

The new mod calls for submitting entries now only require the bare minimum info needed to make an entry. Other optional data is no longer submitted as its own argument, but instead added to a `Dictionary<string, obj>` at the end of the call if needed. The new argument ordering is the following:

### 1.) EntryType
`string` - The message being passed will determine what type of entry will be added. AddBoss type messages have been changed and modders must update them.
- `AddBoss` or `AddBossWithInfo` --> `LogBoss`
- `AddMiniBoss` or `AddMiniBossWithInfo` --> `LogMiniBoss`
- `AddEvent` or `AddEventWithInfo` --> `LogEvent`

### 2.) Mod Instance
`Mod` - The mod will be grabbed to directly get the mod's internal and display names.

### 3.) Internal Name
`string` - Mod developers can choose a unique string to identify their boss to be built into the boss key. The passed string can only contain letters and must have no whitespace characters.

### 4.) Progression Value
`float` - The float value that will determine the entry's progression position on the list.

### 5.) Localized Name
`LocalizedText` - A LocalizedText must be passed for the entry's name. `string` variables are no longer supported. Changes to 1.4.4 encourages modders to use translations and most mods that add content use translations anyways.

### 6.) NPC ID List
`int` or `List<int>` - The IDs of any NPCs that are apart of this boss, with the first being the main part of the NPC. 

### 7.) Downed Check
`Func<bool>` - The downed variable needed to mark and entry as defeated.

### 9.) Additional Data (all optional)
`Dictionary<string, object>` - Modders can add a dictionary of objects with string keys to add any additional data they may need that isn't required to make an entry. This will also allow us to add more optional data without adding more arguments needed to be passed and checked for (at least until necessary). BossChecklist will look for specific string keys in the dictionary to apply any additional data such as spawn items or despawn messages. The keys can be applied in any order and not all of them have to be present. The current keys that are check for are the following:
- "availability"
- "spawnInfo"
- "spawnItem"
- "collectibles"
- "customPortrait"
- "despawnMessage"
- "overrideHeadTextures"

## Entry Keys
Keys will be different than normal due to the new internalName call argument. I'm still open to changing how internal names are determined, so this may change later down the line too. Keys now use `{ get; init; }` instead of just grabbing the modSource and internalName when requested and is determined upon EntryInfo creation. EntryInfo.internalName has also been outright removed with this change as the Key was the only thing it was used for and that still holds true with this new change.

## Vanilla Entry Submissions
Vanilla entries have been updated accordingly and happen to look a little cleaner as a result. Might also want to look to see if progression values can finally be solidified.

## TODO

- [x] Orphan data should be reworked to accepts objects instead of just `List<int>` or `int` and erhaps expand on what can be modified on any given entry. Another dictionary with string key setup might be in order.
- [x] Despawn Messages should be changed to Func<NPC, LocalizedText>
- [x] Add support for null passes instead of LocalizedText for Name and SpawnInfo. Also add support for despawn messages to use LocalizaedText OR Func<NPC, **string**>