### PR TITLE
Belongs to invasion changes

### DIFF
--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -214,6 +214,12 @@ namespace BossChecklist
 					else if (orphan.type == OrphanType.EventNPC) {
 						if (entry.type == EntryType.Event) {
 							entry.npcIDs.AddRange(InterpretDataAsListOfInt);
+							if (EventKeysWhoHaveBelongToInvasionSets.Contains(entry.Key)) {
+								BossChecklist.instance.Logger.Info(
+								$"{entry.Key} is an event that is supported by tModLoader's 'NPCID.Sets.BelongsToInvasion' sets." +
+								$"SubmitEventNPCs will still be supported, but it is recommended to use the sets where given." +
+								$"Sets when creating ModNPCs to automatically add them to an entry's NPC pool");
+							}
 						}
 						else {
 							BossChecklist.instance.Logger.Warn($"{entry.Key} is not an event entry and cannot take calls from {OrphanType.EventNPC}");
@@ -830,6 +836,14 @@ namespace BossChecklist
 			NPCID.CultistBoss
 		};
 
+		internal readonly static List<string> EventKeysWhoHaveBelongToInvasionSets = new List<string>() {
+			$"Terraria GoblinArmy",
+			$"Terraria OldOnesArmy",
+			$"Terraria FrostLegion",
+			$"Terraria PirateInvasion",
+			$"Terraria MartianMadness",
+		};
+
 		internal readonly static Dictionary<string, List<int>> EventNPCs = new Dictionary<string, List<int>>() {
 			{ "Terraria TorchGod",
 				new List<int>() {
@@ -858,17 +872,9 @@ namespace BossChecklist
 					NPCID.BloodNautilus,
 				}
 			},
-			{ "Terraria GoblinArmy",
-					new List<int>() {
-					NPCID.GoblinScout,
-					NPCID.GoblinPeon,
-					NPCID.GoblinSorcerer,
-					NPCID.GoblinThief,
-					NPCID.GoblinWarrior,
-					NPCID.GoblinArcher,
-					NPCID.GoblinSummoner,
-				}
-			},
+			
+			// Goblin Army uses BelongsToInvasion set
+
 			{ "Terraria OldOnesArmy",
 				new List<int>() {
 					NPCID.DD2GoblinT3,
@@ -885,13 +891,9 @@ namespace BossChecklist
 					NPCID.DD2Betsy
 				}
 			},
-			{ "Terraria FrostLegion",
-				new List<int>() {
-					NPCID.MisterStabby,
-					NPCID.SnowmanGangsta,
-					NPCID.SnowBalla,
-				}
-			},
+			
+			// Frost Legion uses BelongsToInvasion set
+
 			{ "Terraria Eclipse",
 				new List<int>() {
 					NPCID.Eyezor,
@@ -911,18 +913,9 @@ namespace BossChecklist
 					NPCID.MothronSpawn,
 				}
 			},
-			{ "Terraria PirateInvasion",
-				new List<int>() {
-					NPCID.PirateDeckhand,
-					NPCID.PirateDeadeye,
-					NPCID.PirateCorsair,
-					NPCID.PirateCrossbower,
-					NPCID.PirateCaptain,
-					NPCID.PirateGhost,
-					NPCID.Parrot,
-					NPCID.PirateShip,
-				}
-			},
+			
+			// Pirate Invasion uses BelongsToInvasion set
+
 			{ "Terraria PumpkinMoon",
 				new List<int>() {
 					NPCID.Scarecrow1,
@@ -950,23 +943,9 @@ namespace BossChecklist
 					NPCID.IceQueen
 				}
 			},
-			{ "Terraria MartianMadness",
-				new List<int>() {
-					NPCID.MartianSaucerCore,
-					NPCID.MartianSaucer,
-					NPCID.Scutlix,
-					NPCID.ScutlixRider,
-					NPCID.MartianWalker,
-					NPCID.MartianDrone,
-					NPCID.MartianTurret,
-					NPCID.GigaZapper,
-					NPCID.MartianEngineer,
-					NPCID.MartianOfficer,
-					NPCID.RayGunner,
-					NPCID.GrayGrunt,
-					NPCID.BrainScrambler
-				}
-			},
+			
+			// Martian Madness uses BelongsToInvasion set
+
 			{ "Terraria LunarEvent",
 				new List<int>() {
 					NPCID.LunarTowerSolar,

--- a/BossTracker.cs
+++ b/BossTracker.cs
@@ -190,11 +190,16 @@ namespace BossChecklist
 		}
 		*/
 
+		internal void FinalizeEventNPCPools() {
+			foreach (string key in EventKeysWhoHaveBelongToInvasionSets) {
+				FindEntryFromKey(key).npcIDs = GetBelongsToInvasionSet(key).GetTrueIndexes();
+			}
+		}
+
 		internal void FinalizeOrphanData() {
 			foreach (OrphanInfo orphan in ExtraData) {
 				foreach (KeyValuePair<string, object> submission in orphan.values) {
-					EntryInfo entry = FindEntryFromKey(submission.Key);
-					if (entry is null) {
+					if (FindEntryFromKey(submission.Key) is not EntryInfo entry) {
 						BossChecklist.instance.Logger.Warn($"A {orphan.type} call from {orphan.modSource} contains an invalid key ({submission.Key}) and will be ignored.");
 						continue;
 					}
@@ -214,11 +219,11 @@ namespace BossChecklist
 					else if (orphan.type == OrphanType.EventNPC) {
 						if (entry.type == EntryType.Event) {
 							entry.npcIDs.AddRange(InterpretDataAsListOfInt);
-							if (EventKeysWhoHaveBelongToInvasionSets.Contains(entry.Key)) {
+							if (EventKeysWhoHaveBelongToInvasionSets.Contains(submission.Key)) {
 								BossChecklist.instance.Logger.Info(
-								$"{entry.Key} is an event that is supported by tModLoader's 'NPCID.Sets.BelongsToInvasion' sets." +
-								$"SubmitEventNPCs will still be supported, but it is recommended to use the sets where given." +
-								$"Sets when creating ModNPCs to automatically add them to an entry's NPC pool");
+								$"The key '{submission.Key}' is an event that is supported by tModLoader's 'NPCID.Sets.BelongsToInvasion' sets. " +
+								$"SubmitEventNPCs will still be supported, but it is recommended to use the sets instead, where given. " +
+								$"Using these sets for ModNPCs will automatically add them to an entry's NPC pool without additional mod calls.");
 							}
 						}
 						else {
@@ -843,6 +848,17 @@ namespace BossChecklist
 			$"Terraria PirateInvasion",
 			$"Terraria MartianMadness",
 		};
+
+		internal static bool[] GetBelongsToInvasionSet(string Key) {
+			return Key switch {
+				"Terraria GoblinArmy" => NPCID.Sets.BelongsToInvasionGoblinArmy,
+				"Terraria OldOnesArmy" => NPCID.Sets.BelongsToInvasionOldOnesArmy,
+				"Terraria FrostLegion" => NPCID.Sets.BelongsToInvasionFrostLegion,
+				"Terraria PirateInvasion" => NPCID.Sets.BelongsToInvasionPirate,
+				"Terraria MartianMadness" => NPCID.Sets.BelongsToInvasionMartianMadness,
+				_ => null
+			};
+		}
 
 		internal readonly static Dictionary<string, List<int>> EventNPCs = new Dictionary<string, List<int>>() {
 			{ "Terraria TorchGod",

--- a/BossUISystem.cs
+++ b/BossUISystem.cs
@@ -67,6 +67,7 @@ namespace BossChecklist
 
 		public override void AddRecipes() {
 			//bossTracker.FinalizeLocalization();
+			BossChecklist.bossTracker.FinalizeEventNPCPools();
 			BossChecklist.bossTracker.FinalizeOrphanData(); // Add any remaining boss data, including added NPCs, loot, collectibles and spawn items.
 			BossChecklist.bossTracker.FinalizeEntryLootTables(); // Generate boss loot data. Treasurebag is also determined in this.
 			BossChecklist.bossTracker.FinalizeCollectibleTypes(); // Collectible types have to be determined AFTER all items in orphan data has been added.

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -181,13 +181,7 @@ namespace BossChecklist
 			this.modSource = modSource;
 			this.progression = progression;
 			this.downed = downed;
-
-			if (GetBelongsToInvasionSet() is bool[] Set) {
-				this.npcIDs = Set.GetTrueIndexes();
-			}
-			else {
-				this.npcIDs = npcIDs ?? new List<int>();
-			}
+			this.npcIDs = npcIDs ?? new List<int>();
 
 			// Localization checks
 			LocalizedText name = extraData?.ContainsKey("displayName") == true ? extraData["displayName"] as LocalizedText : null;
@@ -283,17 +277,6 @@ namespace BossChecklist
 				if (icons.Count > 0)
 					headIconTextures = () => icons;
 			}
-		}
-
-		internal bool[] GetBelongsToInvasionSet() {
-			return Key switch {
-				"Terraria GoblinArmy" => NPCID.Sets.BelongsToInvasionGoblinArmy,
-				"Terraria OldOnesArmy" => NPCID.Sets.BelongsToInvasionOldOnesArmy,
-				"Terraria FrostLegion" => NPCID.Sets.BelongsToInvasionFrostLegion,
-				"Terraria PirateInvasion" => NPCID.Sets.BelongsToInvasionPirate,
-				"Terraria MartianMadness" => NPCID.Sets.BelongsToInvasionMartianMadness,
-				_ => null
-			};
 		}
 
 		// Workaround for vanilla events with illogical translation keys.

--- a/EntryInfo.cs
+++ b/EntryInfo.cs
@@ -181,7 +181,13 @@ namespace BossChecklist
 			this.modSource = modSource;
 			this.progression = progression;
 			this.downed = downed;
-			this.npcIDs = npcIDs ?? new List<int>();
+
+			if (GetBelongsToInvasionSet() is bool[] Set) {
+				this.npcIDs = Set.GetTrueIndexes();
+			}
+			else {
+				this.npcIDs = npcIDs ?? new List<int>();
+			}
 
 			// Localization checks
 			LocalizedText name = extraData?.ContainsKey("displayName") == true ? extraData["displayName"] as LocalizedText : null;
@@ -277,6 +283,17 @@ namespace BossChecklist
 				if (icons.Count > 0)
 					headIconTextures = () => icons;
 			}
+		}
+
+		internal bool[] GetBelongsToInvasionSet() {
+			return Key switch {
+				"Terraria GoblinArmy" => NPCID.Sets.BelongsToInvasionGoblinArmy,
+				"Terraria OldOnesArmy" => NPCID.Sets.BelongsToInvasionOldOnesArmy,
+				"Terraria FrostLegion" => NPCID.Sets.BelongsToInvasionFrostLegion,
+				"Terraria PirateInvasion" => NPCID.Sets.BelongsToInvasionPirate,
+				"Terraria MartianMadness" => NPCID.Sets.BelongsToInvasionMartianMadness,
+				_ => null
+			};
 		}
 
 		// Workaround for vanilla events with illogical translation keys.


### PR DESCRIPTION
[#106] Changes tested on Thorium's entries, which have both the BelongsToInvasion sets applied and the mod calls to manually add them. Applies the vanilla NPCs as well as Throium's. Logs mention to use sets if modder uses the mod call.